### PR TITLE
feat: add trueline CLI for non-MCP agents

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,6 +148,44 @@ to use trueline tools instead of `read_file` and `shell cat`.
 Codex CLI does not support hooks. The instruction file is the only mechanism
 for tool redirection (~60% compliance).
 
+## CLI (no MCP)
+
+For agents that can run shell commands but don't support MCP, trueline
+provides a standalone CLI with the same hash-verified operations.
+
+### 1. Install
+
+```sh
+npm i -g trueline-mcp
+```
+
+This puts the `trueline` command on your PATH.
+
+### 2. Verify
+
+```sh
+trueline --help
+```
+
+### 3. Configure your agent
+
+Add the contents of `configs/cli/instructions.md` to your agent's system
+prompt or instruction file. This teaches the agent the trueline workflow:
+outline, read targeted ranges, search for edit targets, edit with checksums.
+
+The key rules for the agent:
+
+- Use `trueline read` instead of `cat`
+- Use `trueline edit` instead of `sed` or manual file writes
+- Use `trueline outline` to navigate before reading full files
+- Use `trueline search` to find lines with checksums before editing
+
+### 4. Path access
+
+By default the CLI allows access to the current working directory. Set
+`TRUELINE_ALLOWED_DIRS` to a colon-separated list of additional paths,
+or set `CLAUDE_PROJECT_DIR` to override the project root.
+
 ## CLI hook dispatcher
 
 The `trueline-hook` command is the universal entry point for hook integration:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ CLI, VS Code Copilot, OpenCode, and Codex CLI.
 **Other platforms** (Gemini CLI, VS Code Copilot, OpenCode, Codex CLI):
 See [INSTALL.md](INSTALL.md) for platform-specific setup.
 
+**CLI (no MCP):** For agents that use shell commands instead of MCP, install
+globally with `npm i -g trueline-mcp` and add `configs/cli/instructions.md`
+to your agent's system prompt. See [INSTALL.md](INSTALL.md#cli-no-mcp).
+
 ## Why
 
 AI coding agents read entire files to find one function, then echo back

--- a/bin/trueline.js
+++ b/bin/trueline.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// CLI entry point for npm distribution.
+// Delegates to resolve-binary-cli.cjs which prefers bun > deno > node.
+//
+// Usage:
+//   npx trueline read src/foo.ts
+//   trueline read src/foo.ts        # after npm i -g trueline-mcp
+
+import { execFileSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const script = resolve(__dirname, "..", "scripts", "resolve-binary-cli.cjs");
+
+try {
+  execFileSync("node", [script, ...process.argv.slice(2)], { stdio: "inherit" });
+} catch (err) {
+  process.exit(err.status ?? 1);
+}

--- a/configs/cli/instructions.md
+++ b/configs/cli/instructions.md
@@ -1,0 +1,61 @@
+# trueline CLI
+
+trueline provides hash-verified file operations via the command line.
+Use trueline commands instead of cat, grep, and sed for reading and
+editing files. Edits are verified against checksums to prevent stale
+overwrites.
+
+## Commands
+
+- **trueline read** — Read a file with per-line hashes and range checksums.
+- **trueline edit** — Apply hash-verified edits. Each edit needs a checksum from a prior read or search.
+- **trueline outline** — Compact structural outline (functions, classes, types with line ranges).
+- **trueline search** — Search a file for a string or regex. Returns matching lines with hashes, ready for editing.
+- **trueline diff** — Semantic AST-based diff vs a git ref.
+- **trueline verify** — Check if held checksums are still valid.
+
+Run `trueline --help` or `trueline <command> --help` for full usage.
+
+## Workflow
+
+1. **Navigate:** `trueline outline src/foo.ts` to see structure without reading the full file.
+2. **Read targeted ranges:** `trueline read src/foo.ts --ranges 10-25` to read only what you need.
+3. **Find edit targets:** `trueline search src/foo.ts "oldFunction"` to get lines with checksums.
+4. **Edit with verification:** `trueline edit src/foo.ts --edits '[{"checksum":"...","range":"...","content":"..."}]'`
+5. **Preview first (optional):** Add `--dry-run` to see a unified diff without writing.
+
+## Rules
+
+- Never use `cat` to read files; use `trueline read` instead.
+- Never use `sed` or manual file writes; use `trueline edit` instead.
+- Use `trueline outline` for navigation; only read specific ranges you need.
+- Always pass the checksum from `trueline read` or `trueline search` when editing.
+- If an edit fails with a checksum mismatch, re-read the file to get fresh checksums.
+
+## Edit format
+
+The `--edits` flag takes a JSON array. Each edit object has:
+
+- `checksum` — Range checksum from a prior read (format: `startLine-endLine:hexhash`)
+- `range` — Lines to replace (format: `startLine:lineHash-endLine:lineHash`)
+- `content` — New content for those lines
+
+Example:
+
+```sh
+trueline edit src/foo.ts --edits '[{
+  "checksum": "10-15:a1b2c3d4",
+  "range": "10:ab-15:cd",
+  "content": "function newName() {\n  return true;\n}"
+}]'
+```
+
+To insert after a line (without replacing), use `+lineNum:hash` as the range:
+
+```sh
+trueline edit src/foo.ts --edits '[{
+  "checksum": "10-15:a1b2c3d4",
+  "range": "+12:ef",
+  "content": "// inserted after line 12"
+}]'
+```

--- a/configs/cli/instructions.md
+++ b/configs/cli/instructions.md
@@ -37,7 +37,10 @@ Run `trueline --help` or `trueline <command> --help` for full usage.
 The `--edits` flag takes a JSON array. Each edit object has:
 
 - `checksum` — Range checksum from a prior read (format: `startLine-endLine:hexhash`)
-- `range` — Lines to replace (format: `startLine:lineHash-endLine:lineHash`)
+- `range` — Target lines, in one of three formats:
+  - `startLine:lineHash-endLine:lineHash` — replace lines
+  - `+lineNum:hash` — insert after line
+  - `+0:` — insert at beginning of file
 - `content` — New content for those lines
 
 Example:
@@ -57,5 +60,15 @@ trueline edit src/foo.ts --edits '[{
   "checksum": "10-15:a1b2c3d4",
   "range": "+12:ef",
   "content": "// inserted after line 12"
+}]'
+```
+
+To insert at the beginning of a file, use `+0:` as the range:
+
+```sh
+trueline edit src/foo.ts --edits '[{
+  "checksum": "1-1:a1b2c3d4",
+  "range": "+0:",
+  "content": "// Copyright 2025 Acme Corp\n// SPDX-License-Identifier: MIT\n"
 }]'
 ```

--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
   ],
   "bin": {
     "trueline-mcp": "./bin/trueline-mcp.js",
-    "trueline-hook": "./bin/trueline-hook.js"
+    "trueline-hook": "./bin/trueline-hook.js",
+    "trueline": "./bin/trueline.js"
   },
   "files": [
     "dist/",
     "bin/",
     "scripts/resolve-binary.cjs",
+    "scripts/resolve-binary-cli.cjs",
     "hooks/",
     "configs/",
     "src/security.js",
@@ -38,7 +40,7 @@
   ],
   "scripts": {
     "dev": "bun run src/server.ts",
-    "build": "bun build src/server.ts --target=node --minify --outfile dist/server.js",
+    "build": "bun build src/server.ts --target=node --minify --outfile dist/server.js && bun build src/cli.ts --target=node --minify --outfile dist/cli.js",
     "prepublishOnly": "bun run build",
     "typecheck": "bun x tsc --noEmit",
     "test": "bun test",

--- a/scripts/resolve-binary-cli.cjs
+++ b/scripts/resolve-binary-cli.cjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn, execFileSync } = require("node:child_process");
+const { existsSync } = require("node:fs");
+const path = require("node:path");
+
+const pluginRoot = path.join(__dirname, "..");
+
+// ==============================================================================
+// Runtime Selection
+// ==============================================================================
+
+function hasBun() {
+  try {
+    execFileSync("bun", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasDeno() {
+  try {
+    execFileSync("deno", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ==============================================================================
+// Dependency Installation
+// ==============================================================================
+
+function ensureDeps() {
+  if (existsSync(path.join(pluginRoot, "node_modules"))) return;
+
+  process.stderr.write("trueline: installing dependencies (first run)...\n");
+  try {
+    const installer = hasBun() ? "bun" : "npm";
+    const args = installer === "bun" ? ["install"] : ["install", "--production"];
+    execFileSync(installer, args, {
+      cwd: pluginRoot,
+      stdio: ["ignore", "ignore", "inherit"],
+      timeout: 120_000,
+    });
+    process.stderr.write("trueline: dependencies installed.\n");
+  } catch (err) {
+    process.stderr.write(
+      `trueline: dependency install failed (${err.message}). trueline_outline will be unavailable.\n`,
+    );
+  }
+}
+
+// ==============================================================================
+// Launch
+// ==============================================================================
+
+ensureDeps();
+
+let cmd, args;
+if (hasBun()) {
+  cmd = "bun";
+  args = [path.join(pluginRoot, "src", "cli.ts")];
+} else if (hasDeno()) {
+  cmd = "deno";
+  args = ["run", "-A", path.join(pluginRoot, "dist", "cli.js")];
+} else {
+  cmd = "node";
+  args = [path.join(pluginRoot, "dist", "cli.js")];
+}
+
+const child = spawn(cmd, [...args, ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+child.on("error", (err) => {
+  process.stderr.write(`trueline: failed to start: ${err.message}\n`);
+  process.exit(1);
+});
+
+child.on("exit", (code) => process.exit(code ?? 1));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,307 @@
+// ==============================================================================
+// CLI entry point — thin dispatch layer over existing tool handlers
+// ==============================================================================
+//
+// Parses process.argv and calls the same handle* functions used by the MCP
+// server, printing results to stdout/stderr. No arg-parser dependency.
+
+import { realpath } from "node:fs/promises";
+import { handleRead } from "./tools/read.ts";
+import { handleEdit } from "./tools/edit.ts";
+import { handleDiff } from "./tools/diff.ts";
+import { handleOutline } from "./tools/outline.ts";
+import { handleSearch } from "./tools/search.ts";
+import { handleVerify } from "./tools/verify.ts";
+import type { ToolResult } from "./tools/types.ts";
+
+const COMMANDS = new Set(["read", "edit", "outline", "search", "diff", "verify"]);
+
+export interface ParsedArgs {
+  command: string;
+  params: Record<string, unknown>;
+}
+
+// ==============================================================================
+// Arg Parsing
+// ==============================================================================
+
+/**
+ * Parse CLI args into a command + params object matching the handle* interfaces.
+ * Exported for testing; the main() function calls this with process.argv.slice(2).
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const [command, ...rest] = argv;
+
+  if (!command || !COMMANDS.has(command)) {
+    throw new Error(`Unknown command: ${command ?? "(none)"}. Available: ${[...COMMANDS].join(", ")}`);
+  }
+
+  switch (command) {
+    case "read":
+      return { command, params: parseRead(rest) };
+    case "edit":
+      return { command, params: parseEdit(rest) };
+    case "outline":
+      return { command, params: parseOutline(rest) };
+    case "search":
+      return { command, params: parseSearch(rest) };
+    case "diff":
+      return { command, params: parseDiff(rest) };
+    case "verify":
+      return { command, params: parseVerify(rest) };
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}
+
+// Consume the next arg, throwing if missing.
+function requireArg(args: string[], i: number, name: string): string {
+  if (i >= args.length) throw new Error(`Missing value for ${name}`);
+  return args[i];
+}
+
+// Collect contiguous non-flag args starting at index i.
+function collectValues(args: string[], start: number): { values: string[]; nextIndex: number } {
+  const values: string[] = [];
+  let i = start;
+  while (i < args.length && !args[i].startsWith("--")) {
+    values.push(args[i]);
+    i++;
+  }
+  return { values, nextIndex: i };
+}
+
+function parseRead(args: string[]): Record<string, unknown> {
+  if (args.length === 0 || args[0].startsWith("--")) throw new Error("read requires a file path");
+  const params: Record<string, unknown> = { file_path: args[0] };
+  let i = 1;
+  while (i < args.length) {
+    switch (args[i]) {
+      case "--ranges": {
+        i++;
+        const { values, nextIndex } = collectValues(args, i);
+        if (values.length === 0) throw new Error("--ranges requires at least one value");
+        params.ranges = values;
+        i = nextIndex;
+        break;
+      }
+      case "--encoding":
+        i++;
+        params.encoding = requireArg(args, i, "--encoding");
+        i++;
+        break;
+      case "--no-hashes":
+        params.hashes = false;
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown flag for read: ${args[i]}`);
+    }
+  }
+  return params;
+}
+
+function parseEdit(args: string[]): Record<string, unknown> {
+  if (args.length === 0 || args[0].startsWith("--")) throw new Error("edit requires a file path");
+  const params: Record<string, unknown> = { file_path: args[0] };
+  let i = 1;
+  while (i < args.length) {
+    switch (args[i]) {
+      case "--edits":
+        i++;
+        params.edits = JSON.parse(requireArg(args, i, "--edits"));
+        i++;
+        break;
+      case "--encoding":
+        i++;
+        params.encoding = requireArg(args, i, "--encoding");
+        i++;
+        break;
+      case "--dry-run":
+        params.dry_run = true;
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown flag for edit: ${args[i]}`);
+    }
+  }
+  if (!params.edits) throw new Error("edit requires --edits '<json array>'");
+  return params;
+}
+
+function parseOutline(args: string[]): Record<string, unknown> {
+  const file_paths: string[] = [];
+  const params: Record<string, unknown> = {};
+  let i = 0;
+
+  // Collect positional file paths first
+  while (i < args.length && !args[i].startsWith("--")) {
+    file_paths.push(args[i]);
+    i++;
+  }
+  if (file_paths.length === 0) throw new Error("outline requires at least one file path");
+  params.file_paths = file_paths;
+
+  while (i < args.length) {
+    switch (args[i]) {
+      case "--depth":
+        i++;
+        params.depth = Number.parseInt(requireArg(args, i, "--depth"), 10);
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown flag for outline: ${args[i]}`);
+    }
+  }
+  return params;
+}
+
+function parseSearch(args: string[]): Record<string, unknown> {
+  if (args.length === 0 || args[0].startsWith("--")) throw new Error("search requires a file path");
+  if (args.length < 2 || args[1].startsWith("--")) throw new Error("search requires a pattern");
+  const params: Record<string, unknown> = { file_path: args[0], pattern: args[1] };
+  let i = 2;
+  while (i < args.length) {
+    switch (args[i]) {
+      case "--context":
+        i++;
+        params.context_lines = Number.parseInt(requireArg(args, i, "--context"), 10);
+        i++;
+        break;
+      case "--max-matches":
+        i++;
+        params.max_matches = Number.parseInt(requireArg(args, i, "--max-matches"), 10);
+        i++;
+        break;
+      case "--case-insensitive":
+        params.case_insensitive = true;
+        i++;
+        break;
+      case "--regex":
+        params.regex = true;
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown flag for search: ${args[i]}`);
+    }
+  }
+  return params;
+}
+
+function parseDiff(args: string[]): Record<string, unknown> {
+  const file_paths: string[] = [];
+  const params: Record<string, unknown> = {};
+  let i = 0;
+
+  while (i < args.length && !args[i].startsWith("--")) {
+    file_paths.push(args[i]);
+    i++;
+  }
+  // Default to all changed files when none specified
+  params.file_paths = file_paths.length > 0 ? file_paths : ["*"];
+
+  while (i < args.length) {
+    switch (args[i]) {
+      case "--ref":
+        i++;
+        params.compare_against = requireArg(args, i, "--ref");
+        i++;
+        break;
+      default:
+        throw new Error(`Unknown flag for diff: ${args[i]}`);
+    }
+  }
+  return params;
+}
+
+function parseVerify(args: string[]): Record<string, unknown> {
+  if (args.length === 0 || args[0].startsWith("--")) throw new Error("verify requires a file path");
+  const params: Record<string, unknown> = { file_path: args[0] };
+  let i = 1;
+  while (i < args.length) {
+    switch (args[i]) {
+      case "--checksums": {
+        i++;
+        const { values, nextIndex } = collectValues(args, i);
+        if (values.length === 0) throw new Error("--checksums requires at least one value");
+        params.checksums = values;
+        i = nextIndex;
+        break;
+      }
+      default:
+        throw new Error(`Unknown flag for verify: ${args[i]}`);
+    }
+  }
+  if (!params.checksums) throw new Error("verify requires --checksums");
+  return params;
+}
+
+// ==============================================================================
+// Dispatch
+// ==============================================================================
+
+type Handler = (params: Record<string, unknown>) => Promise<ToolResult>;
+
+function buildHandlerMap(projectDir: string, allowedDirs: string[]): Record<string, Handler> {
+  return {
+    read: (p) => handleRead({ ...p, projectDir, allowedDirs } as Parameters<typeof handleRead>[0]),
+    edit: (p) => handleEdit({ ...p, projectDir, allowedDirs } as Parameters<typeof handleEdit>[0]),
+    diff: (p) => handleDiff({ ...p, projectDir, allowedDirs } as Parameters<typeof handleDiff>[0]),
+    outline: (p) => handleOutline({ ...p, projectDir, allowedDirs } as Parameters<typeof handleOutline>[0]),
+    search: (p) => handleSearch({ ...p, projectDir, allowedDirs } as Parameters<typeof handleSearch>[0]),
+    verify: (p) => handleVerify({ ...p, projectDir, allowedDirs } as Parameters<typeof handleVerify>[0]),
+  };
+}
+
+// ==============================================================================
+// Main
+// ==============================================================================
+
+async function resolveAllowedDirs(projectDir: string): Promise<string[]> {
+  const dirs = [projectDir];
+  const envDirs = process.env.TRUELINE_ALLOWED_DIRS;
+  if (envDirs) {
+    for (const d of envDirs.split(":")) {
+      const trimmed = d.trim();
+      if (trimmed) dirs.push(await realpath(trimmed).catch(() => trimmed));
+    }
+  }
+  return dirs;
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const parsed = parseArgs(argv);
+
+  const rawProjectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+  const projectDir = await realpath(rawProjectDir).catch(() => rawProjectDir);
+  const allowedDirs = await resolveAllowedDirs(projectDir);
+
+  const handlers = buildHandlerMap(projectDir, allowedDirs);
+  const handler = handlers[parsed.command];
+  const result = await handler(parsed.params);
+
+  if (result.isError) {
+    process.stderr.write(typeof result.content === "string" ? result.content : JSON.stringify(result.content));
+    process.stderr.write("\n");
+    process.exitCode = 1;
+  } else {
+    const text =
+      typeof result.content === "string"
+        ? result.content
+        : Array.isArray(result.content)
+          ? result.content.map((c: { text?: string }) => c.text ?? "").join("")
+          : JSON.stringify(result.content);
+    process.stdout.write(text);
+    // Add trailing newline if output doesn't end with one
+    if (!text.endsWith("\n")) process.stdout.write("\n");
+  }
+}
+
+// Run when executed directly
+const isDirectRun = process.argv[1]?.endsWith("cli.ts") || process.argv[1]?.endsWith("cli.js");
+if (isDirectRun) {
+  main().catch((err) => {
+    process.stderr.write(`trueline: ${err.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@
 // server, printing results to stdout/stderr. No arg-parser dependency.
 
 import { realpath } from "node:fs/promises";
+import { delimiter } from "node:path";
 import { handleRead } from "./tools/read.ts";
 import { handleEdit } from "./tools/edit.ts";
 import { handleDiff } from "./tools/diff.ts";
@@ -345,7 +346,7 @@ async function resolveAllowedDirs(projectDir: string): Promise<string[]> {
   const dirs = [projectDir];
   const envDirs = process.env.TRUELINE_ALLOWED_DIRS;
   if (envDirs) {
-    for (const d of envDirs.split(":")) {
+    for (const d of envDirs.split(delimiter).filter(Boolean)) {
       const trimmed = d.trim();
       if (trimmed) dirs.push(await realpath(trimmed).catch(() => trimmed));
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,82 @@ export interface ParsedArgs {
   params: Record<string, unknown>;
 }
 
+// Sentinel returned by parseArgs when --help is requested.
+// main() prints the help text to stdout and exits 0.
+export class HelpRequested {
+  constructor(public text: string) {}
+}
+
+const USAGE = `trueline <command> [options]
+
+Hash-verified file operations for AI coding agents.
+
+Commands:
+  read      Read a file with per-line hashes and range checksums
+  edit      Apply hash-verified edits to a file
+  outline   Structural outline (functions, classes, types) via tree-sitter
+  search    Search a file for a string or regex, returns edit-ready hashes
+  diff      Semantic AST-based diff vs a git ref
+  verify    Check if held checksums are still valid
+
+Run trueline <command> --help for command-specific usage.`;
+
+const COMMAND_HELP: Record<string, string> = {
+  read: `trueline read <file> [options]
+
+Read a file with per-line hashes and range checksums.
+
+Options:
+  --ranges <range...>   Line ranges to read (e.g. 10-25 200-220)
+  --encoding <enc>      File encoding (default: utf-8)
+  --no-hashes           Omit per-line hashes from output`,
+
+  edit: `trueline edit <file> --edits '<json>' [options]
+
+Apply hash-verified edits to a file.
+
+Options:
+  --edits <json>        JSON array of edits (required)
+                        Each edit: {checksum, range, content}
+  --encoding <enc>      File encoding (default: utf-8)
+  --dry-run             Preview as unified diff without writing`,
+
+  outline: `trueline outline <file...> [options]
+
+Structural outline of one or more files via tree-sitter.
+Returns functions, classes, types with line ranges.
+
+Options:
+  --depth <n>           Max nesting depth (0 = top-level only)`,
+
+  search: `trueline search <file> <pattern> [options]
+
+Search a file for a literal string or regex.
+Returns matching lines with hashes, ready for editing.
+
+Options:
+  --context <n>         Lines of context around matches (default: 0)
+  --max-matches <n>     Stop after n matches
+  --regex               Treat pattern as a regex
+  --case-insensitive    Case-insensitive matching`,
+
+  diff: `trueline diff [file...] [options]
+
+Semantic AST-based diff vs a git ref.
+With no files, diffs all changed files.
+
+Options:
+  --ref <ref>           Git ref to compare against (default: working tree)`,
+
+  verify: `trueline verify <file> --checksums <checksum...>
+
+Check if held checksums are still valid.
+
+Options:
+  --checksums <cs...>   Range checksums to verify (required)
+                        Format: startLine-endLine:hexhash`,
+};
+
 // ==============================================================================
 // Arg Parsing
 // ==============================================================================
@@ -29,11 +105,19 @@ export interface ParsedArgs {
  * Parse CLI args into a command + params object matching the handle* interfaces.
  * Exported for testing; the main() function calls this with process.argv.slice(2).
  */
-export function parseArgs(argv: string[]): ParsedArgs {
+export function parseArgs(argv: string[]): ParsedArgs | HelpRequested {
   const [command, ...rest] = argv;
 
-  if (!command || !COMMANDS.has(command)) {
-    throw new Error(`Unknown command: ${command ?? "(none)"}. Available: ${[...COMMANDS].join(", ")}`);
+  if (!command || command === "--help" || command === "-h") {
+    return new HelpRequested(USAGE);
+  }
+
+  if (!COMMANDS.has(command)) {
+    throw new Error(`Unknown command: ${command}. Available: ${[...COMMANDS].join(", ")}`);
+  }
+
+  if (rest.includes("--help") || rest.includes("-h")) {
+    return new HelpRequested(COMMAND_HELP[command]);
   }
 
   switch (command) {
@@ -271,6 +355,12 @@ async function resolveAllowedDirs(projectDir: string): Promise<string[]> {
 
 export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
   const parsed = parseArgs(argv);
+
+  if (parsed instanceof HelpRequested) {
+    process.stdout.write(parsed.text);
+    process.stdout.write("\n");
+    return;
+  }
 
   const rawProjectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
   const projectDir = await realpath(rawProjectDir).catch(() => rawProjectDir);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,12 @@ Options:
   --edits <json>        JSON array of edits (required)
                         Each edit: {checksum, range, content}
   --encoding <enc>      File encoding (default: utf-8)
-  --dry-run             Preview as unified diff without writing`,
+  --dry-run             Preview as unified diff without writing
+
+Range formats:
+  startLine:hash-endLine:hash   Replace lines (from trueline read/search)
+  +lineNum:hash                 Insert after line
+  +0:                           Insert at beginning of file`,
 
   outline: `trueline outline <file...> [options]
 

--- a/tests/cli-integration.test.ts
+++ b/tests/cli-integration.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test, beforeAll } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+
+let tmpDir: string;
+let testFile: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "trueline-cli-"));
+  testFile = join(tmpDir, "test.txt");
+  writeFileSync(testFile, "line one\nline two\nline three\n");
+});
+
+function run(...args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync("bun", [CLI, ...args], {
+      encoding: "utf-8",
+      timeout: 15_000,
+      env: { ...process.env, TRUELINE_ALLOWED_DIRS: tmpDir },
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout?.toString() ?? "",
+      stderr: err.stderr?.toString() ?? "",
+      exitCode: err.status ?? 1,
+    };
+  }
+}
+
+describe("CLI integration", () => {
+  test("read prints file with hashes", () => {
+    const { stdout, exitCode } = run("read", testFile);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("line one");
+    expect(stdout).toContain("line two");
+    // Should contain checksum line
+    expect(stdout).toMatch(/checksum:/);
+  });
+
+  test("read with --no-hashes omits per-line hashes", () => {
+    const { stdout, exitCode } = run("read", testFile, "--no-hashes");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("line one");
+  });
+
+  test("read with --ranges", () => {
+    const { stdout, exitCode } = run("read", testFile, "--ranges", "1-2");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("line one");
+    expect(stdout).toContain("line two");
+    expect(stdout).not.toContain("line three");
+  });
+
+  test("search finds matches", () => {
+    const { stdout, exitCode } = run("search", testFile, "two");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("line two");
+  });
+
+  // Tree-sitter WASM init is slow in a cold subprocess
+  test(
+    "outline works on TypeScript file",
+    () => {
+      const tsFile = join(tmpDir, "example.ts");
+      writeFileSync(tsFile, "export function hello(): string { return 'hi'; }\n");
+      const { stdout, exitCode } = run("outline", tsFile);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("hello");
+    },
+    { timeout: 30_000 },
+  );
+
+  test("unknown command exits 1", () => {
+    const { stderr, exitCode } = run("bogus");
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Unknown command");
+  });
+
+  test("read nonexistent file exits 1", () => {
+    const { exitCode } = run("read", "/nonexistent/file.txt");
+    expect(exitCode).toBe(1);
+  });
+
+  test("verify with stale checksum reports stale", () => {
+    // First read to get a checksum
+    const { stdout } = run("read", testFile);
+    const checksumMatch = stdout.match(/checksum: (\S+)/);
+    expect(checksumMatch).toBeTruthy();
+    // Use a bogus checksum
+    const { stdout: verifyOut, exitCode } = run("verify", testFile, "--checksums", "1-3:deadbeef");
+    expect(exitCode).toBe(0);
+    expect(verifyOut).toContain("stale");
+  });
+});

--- a/tests/cli-integration.test.ts
+++ b/tests/cli-integration.test.ts
@@ -75,6 +75,19 @@ describe("CLI integration", () => {
     { timeout: 30_000 },
   );
 
+  test("--help prints usage and exits 0", () => {
+    const { stdout, exitCode } = run("--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Commands:");
+    expect(stdout).toContain("read");
+  });
+
+  test("command --help prints command usage", () => {
+    const { stdout, exitCode } = run("read", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--ranges");
+  });
+
   test("unknown command exits 1", () => {
     const { stderr, exitCode } = run("bogus");
     expect(exitCode).toBe(1);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseArgs } from "../src/cli.ts";
+import { HelpRequested, parseArgs } from "../src/cli.ts";
 
 describe("parseArgs", () => {
   test("read with file path", () => {
@@ -91,6 +91,28 @@ describe("parseArgs", () => {
       command: "verify",
       params: { file_path: "src/foo.ts", checksums: ["1-50:abcdef01", "51-100:12345678"] },
     });
+  });
+
+  test("--help returns top-level usage", () => {
+    const result = parseArgs(["--help"]);
+    expect(result).toBeInstanceOf(HelpRequested);
+    expect((result as HelpRequested).text).toContain("Commands:");
+  });
+
+  test("no args returns top-level usage", () => {
+    const result = parseArgs([]);
+    expect(result).toBeInstanceOf(HelpRequested);
+  });
+
+  test("command --help returns command usage", () => {
+    const result = parseArgs(["read", "--help"]);
+    expect(result).toBeInstanceOf(HelpRequested);
+    expect((result as HelpRequested).text).toContain("--ranges");
+  });
+
+  test("-h works as alias for --help", () => {
+    expect(parseArgs(["-h"])).toBeInstanceOf(HelpRequested);
+    expect(parseArgs(["search", "-h"])).toBeInstanceOf(HelpRequested);
   });
 
   test("unknown command errors", () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "../src/cli.ts";
+
+describe("parseArgs", () => {
+  test("read with file path", () => {
+    const result = parseArgs(["read", "src/foo.ts"]);
+    expect(result).toEqual({
+      command: "read",
+      params: { file_path: "src/foo.ts" },
+    });
+  });
+
+  test("read with ranges and no-hashes", () => {
+    const result = parseArgs(["read", "src/foo.ts", "--ranges", "10-25", "200-220", "--no-hashes"]);
+    expect(result).toEqual({
+      command: "read",
+      params: { file_path: "src/foo.ts", ranges: ["10-25", "200-220"], hashes: false },
+    });
+  });
+
+  test("read with encoding", () => {
+    const result = parseArgs(["read", "src/foo.ts", "--encoding", "latin1"]);
+    expect(result).toEqual({
+      command: "read",
+      params: { file_path: "src/foo.ts", encoding: "latin1" },
+    });
+  });
+
+  test("edit with edits JSON and dry-run", () => {
+    const edits = JSON.stringify([{ checksum: "1-5:abcdef01", range: "1:ab-5:cd", content: "hello" }]);
+    const result = parseArgs(["edit", "src/foo.ts", "--edits", edits, "--dry-run"]);
+    expect(result).toEqual({
+      command: "edit",
+      params: {
+        file_path: "src/foo.ts",
+        edits: [{ checksum: "1-5:abcdef01", range: "1:ab-5:cd", content: "hello" }],
+        dry_run: true,
+      },
+    });
+  });
+
+  test("outline with multiple files and depth", () => {
+    const result = parseArgs(["outline", "src/a.ts", "src/b.ts", "--depth", "1"]);
+    expect(result).toEqual({
+      command: "outline",
+      params: { file_paths: ["src/a.ts", "src/b.ts"], depth: 1 },
+    });
+  });
+
+  test("search with pattern and flags", () => {
+    const result = parseArgs(["search", "src/foo.ts", "handleRead", "--context", "3", "--regex", "--case-insensitive"]);
+    expect(result).toEqual({
+      command: "search",
+      params: {
+        file_path: "src/foo.ts",
+        pattern: "handleRead",
+        context_lines: 3,
+        regex: true,
+        case_insensitive: true,
+      },
+    });
+  });
+
+  test("search with max-matches", () => {
+    const result = parseArgs(["search", "src/foo.ts", "TODO", "--max-matches", "5"]);
+    expect(result).toEqual({
+      command: "search",
+      params: { file_path: "src/foo.ts", pattern: "TODO", max_matches: 5 },
+    });
+  });
+
+  test("diff with files and ref", () => {
+    const result = parseArgs(["diff", "src/a.ts", "src/b.ts", "--ref", "main"]);
+    expect(result).toEqual({
+      command: "diff",
+      params: { file_paths: ["src/a.ts", "src/b.ts"], compare_against: "main" },
+    });
+  });
+
+  test("diff with no files defaults to all changed", () => {
+    const result = parseArgs(["diff"]);
+    expect(result).toEqual({
+      command: "diff",
+      params: { file_paths: ["*"] },
+    });
+  });
+
+  test("verify with checksums", () => {
+    const result = parseArgs(["verify", "src/foo.ts", "--checksums", "1-50:abcdef01", "51-100:12345678"]);
+    expect(result).toEqual({
+      command: "verify",
+      params: { file_path: "src/foo.ts", checksums: ["1-50:abcdef01", "51-100:12345678"] },
+    });
+  });
+
+  test("unknown command errors", () => {
+    expect(() => parseArgs(["bogus"])).toThrow();
+  });
+
+  test("missing file_path errors", () => {
+    expect(() => parseArgs(["read"])).toThrow();
+  });
+
+  test("search missing pattern errors", () => {
+    expect(() => parseArgs(["search", "src/foo.ts"])).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `trueline` CLI binary that dispatches to existing `handle*` functions via
  `src/cli.ts`, with hand-rolled arg parser (no dependencies)
- Add `--help` and per-command `--help` for AI agent discoverability
- Add bin shim (`bin/trueline.js`) and runtime resolver (`scripts/resolve-binary-cli.cjs`)
  matching the existing MCP server pattern (bun > deno > node)
- Build script now produces both `dist/server.js` and `dist/cli.js`
- Add `configs/cli/instructions.md` as a drop-in system prompt for agents
- Document CLI installation in `INSTALL.md` and `README.md`

## Test Plan

- 17 unit tests for arg parsing (`tests/cli.test.ts`)
- 10 integration tests running CLI as subprocess (`tests/cli-integration.test.ts`)
- Full suite: 469 tests, 0 failures
- Manual smoke tests: read, outline, search, diff, --help all verified