### PR TITLE
refactor(protocol): remove per-line hashes from edit protocol

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,8 +1,8 @@
 # trueline Protocol Design
 
-trueline is a file-editing protocol for AI agents. Every line the agent
-reads carries a short content hash, and every edit must present those
-hashes back — proving the agent is working against the file's actual
+trueline is a file-editing protocol for AI agents. Every read returns
+range checksums over the lines, and every edit must present those
+checksums back, proving the agent is working against the file's actual
 content rather than a stale or hallucinated version.
 
 This document explains how the core tools — `trueline_read`,
@@ -22,41 +22,33 @@ tool-use setups), two things can go wrong silently:
    text it's trying to match. The edit either fails to find a match or
    matches an unintended location.
 
-trueline prevents both by requiring the agent to echo back per-line
-hashes and a range checksum. If anything is wrong, the edit is rejected
-before any bytes hit disk.
+trueline prevents both by requiring the agent to echo back a range
+checksum. If anything is wrong, the edit is rejected before any bytes
+hit disk.
 
 ## Line format
 
 `trueline_read` returns each line in this format:
 
 ```
-{lineNumber}:{hash}|{content}
+{lineNumber}|{content}
 ```
 
 For example, reading a three-line file:
 
 ```
-1:ab|#!/usr/bin/env node
-2:mp|import { readFile } from "fs/promises";
-3:qk|console.log("hello");
+1|#!/usr/bin/env node
+2|import { readFile } from "fs/promises";
+3|console.log("hello");
 
 checksum: 1-3:f7e2a1b0
 ```
 
-The **hash** is two characters from a 32-symbol alphabet (`a-z` plus
-`2-7`) derived from the line's content via FNV-1a (a fast,
-non-cryptographic hash). Two characters give 1024 possible values —
-enough to catch accidental mismatches, not enough to be a security
-mechanism.
-
 The **checksum** covers the entire range of lines returned. Its format
 is `startLine-endLine:8hex`, where the hex is an FNV-1a accumulator
-over the full 32-bit hashes of each line in the range. This is
-deliberately stronger than the 2-letter per-line hashes: the
-accumulator feeds all four bytes of each line's hash into a second
-FNV-1a pass, giving much better collision resistance over the whole
-range.
+over the full 32-bit hashes of each line in the range. This feeds all
+four bytes of each line's hash into a second FNV-1a pass, giving good
+collision resistance over the whole range.
 
 ## Reading: `trueline_read`
 
@@ -77,7 +69,7 @@ file into memory. The pipeline:
    `\r`), yielding one decoded string per line. Lines before
    `start_line` are counted and skipped; lines after `end_line` stop
    the stream early.
-4. Computes FNV-1a hashes and formats as truelines.
+4. Computes FNV-1a hashes per line and accumulates the range checksum.
 5. Computes and appends the range checksum.
 
 ### Partial reads
@@ -92,15 +84,6 @@ Multiple disjoint ranges can be read in a single call, each producing
 its own checksum. This is useful when editing lines in different parts
 of a file — one read call provides all the checksums needed.
 
-### Compact reads
-
-When the agent is exploring code without planning to edit, it can pass
-`hashes: false` to omit the per-line 2-letter hashes. The output format
-changes from `N:hash\tcontent` to `N\tcontent`, saving ~3 tokens per line.
-Checksums are always included regardless of the `hashes` setting, so the
-agent can still reference the output for a subsequent targeted re-read
-before editing.
-
 ### Empty files
 
 An empty file returns the sentinel checksum `0-0:00000000`. This
@@ -114,7 +97,7 @@ trueline_edit({
   file_path: "src/main.ts",
   edits: [{
     checksum: "10-25:f7e2a1b0",
-    range: "12:mp..14:qk",
+    range: "12-14",
     content: "  const x = 1;\n  const y = 2;",
   }]
 })
@@ -122,10 +105,10 @@ trueline_edit({
 
 Each edit specifies:
 
-- **`range`** — which lines to replace, as `startLine:hash..endLine:hash`.
-  A single-line shorthand `12:mp` is equivalent to `12:mp..12:mp`.
-  Prefix `+` for insert-after: `+5:ab` inserts content after line 5.
-  Use `+0:` to prepend to the file.
+- **`range`** — which lines to replace, as `startLine-endLine`.
+  A single-line shorthand `12` is equivalent to `12-12`.
+  Prefix `+` for insert-after: `+5` inserts content after line 5.
+  Use `+0` to prepend to the file.
 - **`content`** — the replacement lines as a single newline-separated
   string. The resulting lines can be fewer or more than the range
   (shrinking or growing the file). An empty string deletes the range.
@@ -164,7 +147,7 @@ file is never loaded into memory as a whole.
 2. Open a read stream on the source and a write stream to a temp file.
 3. For each source line:
    a. Hash raw bytes (FNV-1a on the Buffer, no string decode).
-   b. Verify boundary hashes at edit start/end lines.
+   b. Feed the line's hash into the range checksum accumulator.
    c. If the line falls in a replace range, buffer it for no-op
       detection but don't write it to the temp file.
    d. At the end of a replace range, write replacement content.
@@ -369,7 +352,7 @@ trueline_search({
 ```
 
 `trueline_search` searches a file by regex and returns matching lines
-with context, per-line hashes, and checksums — ready for immediate
+with context and checksums — ready for immediate
 editing. It replaces the outline → read → find workflow when the agent
 knows what pattern to look for.
 
@@ -389,13 +372,13 @@ The pipeline:
 5. Early termination: once `max_matches` matches have been captured and
    their post-context is complete, the engine stops decoding lines
    (remaining lines are only scanned for the total match count).
-6. Formats output with per-line hashes and a checksum per context
+6. Formats output with line numbers and a checksum per context
    window.
 
 If `max_matches` is exceeded, the output includes a truncation notice
 with the total match count.
 
-The output is identical in format to `trueline_read` — same `N:hash\t`
+The output is identical in format to `trueline_read` — same `N|`
 prefix, same checksums — so the agent can pass results directly to
 `trueline_edit` without a re-read step.
 
@@ -453,7 +436,7 @@ For each byte `b` of input:
 hash = (hash XOR b) * prime  (mod 2^32)
 ```
 
-### Per-line hash: `fnv1aHash`
+### Line hash: `fnv1aHash`
 
 Input: the line's content as a string, with trailing `\n`, `\r\n`, or
 `\r` stripped. The string is encoded as UTF-8 bytes inline (handling
@@ -464,24 +447,6 @@ The streaming edit engine has a byte-level equivalent,
 `fnv1aHashBytes(buf, start, end)`, that hashes raw UTF-8 bytes from a
 Buffer directly — identical output, no string decode/encode
 round-trip.
-
-### Two-character tag: `hashToLetters`
-
-The 32-bit per-line hash is projected into two characters from a
-32-symbol alphabet (`a-z` plus `2-7`, 1024 combinations) for the
-`N:xy|content` display format:
-
-```
-c1 = HASH_CHARS[hash & 0x1f]          // bits 0-4
-c2 = HASH_CHARS[(hash >>> 8) & 0x1f]  // bits 8-12
-```
-
-The power-of-2 alphabet size allows bitwise AND (`& 0x1f`) instead of
-integer division (`% 26`), which is measurably faster in the hot loop.
-
-This is a lossy mapping to 1024 possible values — a typo detector, not
-a security boundary.
-
 ### Range checksum: `foldHash`
 
 The range checksum is an FNV-1a hash *of hashes*. Starting from the
@@ -500,20 +465,16 @@ is the same.
 
 The result is formatted as `startLine-endLine:8hex`
 (e.g. `1-50:f7e2a1b0`). The 8 hex digits are the full 32-bit
-accumulator, giving much stronger collision resistance than the
-2-letter per-line tags.
+accumulator.
 
-### Three layers of edit protection
+### Two layers of edit protection
 
 | Layer | What it checks | Granularity | Detects |
-|-------|---------------|-------------|---------|
-| Boundary hash | Two-letter tag at edit start/end lines | Single line | Change to the specific lines being replaced |
+|-------|---------------|-------------|--------|
 | Range checksum | FNV-1a accumulator over all lines in the read window | Entire read range | Change to *any* line in the window, even lines not being edited |
 | mtime guard | File modification time before atomic rename | Whole file | Concurrent modification by another process between read and write |
 
-The boundary hash is a fast-fail: the streaming engine checks it the
-moment it reaches an edit's start or end line. The range checksum is
-verified after the full stream completes — it catches changes to lines
-the agent isn't editing but that were included in the `trueline_read`
-window. The mtime guard narrows the TOCTOU window for external
-writers.
+The range checksum is verified after the full stream completes; it
+catches changes to lines the agent isn't editing but that were included
+in the `trueline_read` window. The mtime guard narrows the TOCTOU
+window for external writers.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ overhead, so the break-even point is roughly 15KB; below that, a plain
 | 245 lines   | 245 tokens | 14 tokens | 94% |
 | 504 lines   | 504 tokens | 4 tokens  | 99% |
 
-`trueline_read` supports multiple disjoint ranges in a single call and
-an optional `hashes: false` mode for exploratory reads that saves ~3
-tokens per line.
+`trueline_read` supports multiple disjoint ranges in a single call.
 
 ### Find and fix: `trueline_search`
 
@@ -107,13 +105,13 @@ modifications with inline mini-diffs for small changes.
 Pass `["*"]` to diff all changed files at once. The output is compact
 enough to review an entire feature branch in a single tool call.
 
-### Never corrupt: hash verification
+### Never corrupt: checksum verification
 
-Every line from `trueline_read` carries a content hash. Every edit must
-present those hashes back, proving the agent is working against the
-file's actual content. If anything changed (concurrent edits, model
-hallucination, stale context) the edit is rejected before any bytes hit
-disk.
+Every range from `trueline_read` carries a checksum covering its
+content. Every edit must present a valid checksum back, proving the
+agent is working against the file's actual content. If anything changed
+(concurrent edits, model hallucination, stale context) the edit is
+rejected before any bytes hit disk.
 
 No more silent corruption. No more ambiguous string matches.
 

--- a/benchmarks/perf-benchmark.ts
+++ b/benchmarks/perf-benchmark.ts
@@ -12,7 +12,7 @@ import { handleRead } from "../src/tools/read.ts";
 import { handleSearch } from "../src/tools/search.ts";
 import { handleDiff } from "../src/tools/diff.ts";
 import { streamingEdit } from "../src/streaming-edit.ts";
-import { fnv1aHashBytes, hashToLetters } from "../src/hash.ts";
+import { fnv1aHashBytes } from "../src/hash.ts";
 
 // ===========================================================================
 // Helpers
@@ -153,12 +153,11 @@ async function benchEditSingleLine(): Promise<BenchResult> {
   });
   const text = readResult.content[0].text;
   const checksumMatch = text.match(/checksum: (\S+)/);
-  const lineMatch = text.match(/^(\d+):([a-z0-9]{2})\t(.*)$/m);
+  const lineMatch = text.match(/^(\d+)\t(.*)$/m);
   if (!checksumMatch || !lineMatch) throw new Error("Failed to parse read result for edit benchmark");
 
   const checksumStr = checksumMatch[1];
   const lineNum = Number.parseInt(lineMatch[1], 10);
-  const hash = lineMatch[2];
 
   // Parse checksum string "100-100:abcdef01" → { startLine, endLine, hash }
   const [range, csHash] = checksumStr.split(":");
@@ -172,8 +171,6 @@ async function benchEditSingleLine(): Promise<BenchResult> {
         {
           startLine: lineNum,
           endLine: lineNum,
-          startHash: hash,
-          endHash: hash,
           content: ["const replaced = true;"],
           insertAfter: false,
         },
@@ -194,7 +191,7 @@ async function benchEditMultiLine(): Promise<BenchResult> {
   });
   const text = readResult.content[0].text;
   const checksumMatch = text.match(/checksum: (\S+)/);
-  const lines = text.split("\n").filter((l) => /^\d+:[a-z0-9]{2}\t/.test(l));
+  const lines = text.split("\n").filter((l) => /^\d+\t/.test(l));
   if (!checksumMatch || lines.length === 0)
     throw new Error("Failed to parse read result for multi-line edit benchmark");
 
@@ -202,9 +199,9 @@ async function benchEditMultiLine(): Promise<BenchResult> {
   const [range, csHash] = checksumStr.split(":");
   const [csStart, csEnd] = range.split("-").map(Number);
 
-  const firstMatch = lines[0].match(/^(\d+):([a-z0-9]{2})\t/);
-  const lastMatch = lines[lines.length - 1].match(/^(\d+):([a-z0-9]{2})\t/);
-  if (!firstMatch || !lastMatch) throw new Error("Failed to parse line hashes");
+  const firstMatch = lines[0].match(/^(\d+)\t/);
+  const lastMatch = lines[lines.length - 1].match(/^(\d+)\t/);
+  if (!firstMatch || !lastMatch) throw new Error("Failed to parse line numbers");
 
   const replacement = Array.from({ length: 20 }, (_, i) => `const replaced_${i} = ${i};`);
 
@@ -216,8 +213,6 @@ async function benchEditMultiLine(): Promise<BenchResult> {
         {
           startLine: Number.parseInt(firstMatch[1], 10),
           endLine: Number.parseInt(lastMatch[1], 10),
-          startHash: firstMatch[2],
-          endHash: lastMatch[2],
           content: replacement,
           insertAfter: false,
         },
@@ -235,15 +230,6 @@ function benchHashBytes(): BenchResult {
 
   return benchSync("hash-bytes", 10_000, () => {
     fnv1aHashBytes(buf, 0, buf.length);
-  });
-}
-
-function benchHashToLetters(): BenchResult {
-  const hashes = new Uint32Array(1000);
-  for (let i = 0; i < hashes.length; i++) hashes[i] = (i * 2654435761) >>> 0;
-
-  return benchSync("hash-to-letters", 1000, () => {
-    for (let i = 0; i < hashes.length; i++) hashToLetters(hashes[i]);
   });
 }
 
@@ -336,7 +322,6 @@ async function main(): Promise<void> {
   results.push(await benchEditSingleLine());
   results.push(await benchEditMultiLine());
   results.push(benchHashBytes());
-  results.push(benchHashToLetters());
   results.push(await benchSemanticDiff());
 
   console.log();

--- a/benchmarks/token-benchmark.ts
+++ b/benchmarks/token-benchmark.ts
@@ -203,16 +203,15 @@ async function truelineNavigate(): Promise<ScenarioResult> {
   steps.push({ tool: "outline", callBytes: outlineCall, resultBytes: outputBytes(outline) });
 
   // read targeted range
-  const readCallObj = { file_path: SAMPLE_FILE, ranges: [{ start: 74, end: 150 }], hashes: false };
+  const readCallObj = { file_path: SAMPLE_FILE, ranges: [{ start: 74, end: 150 }] };
   const read = await handleRead({
     file_path: SAMPLE_FILE,
     ranges: [{ start: 74, end: 150 }],
-    hashes: false,
     projectDir: PROJECT_DIR,
     allowedDirs: ALLOWED_DIRS,
   });
   steps.push({
-    tool: "read 74-150 (no hashes)",
+    tool: "read 74-150",
     callBytes: jsonCallBytes(readCallObj),
     resultBytes: outputBytes(read),
   });
@@ -232,12 +231,11 @@ async function truelineExploreEdit(): Promise<ScenarioResult> {
   });
   steps.push({ tool: "outline", callBytes: outlineCall, resultBytes: outputBytes(outline) });
 
-  // exploratory read (no hashes)
-  const exploreCallObj = { file_path: SAMPLE_FILE, ranges: [{ start: 74, end: 250 }], hashes: false };
+  // exploratory read
+  const exploreCallObj = { file_path: SAMPLE_FILE, ranges: [{ start: 74, end: 250 }] };
   const explore = await handleRead({
     file_path: SAMPLE_FILE,
     ranges: [{ start: 74, end: 250 }],
-    hashes: false,
     projectDir: PROJECT_DIR,
     allowedDirs: ALLOWED_DIRS,
   });
@@ -247,7 +245,7 @@ async function truelineExploreEdit(): Promise<ScenarioResult> {
     resultBytes: outputBytes(explore),
   });
 
-  // targeted re-read with hashes for edit
+  // targeted re-read for edit
   const targetCallObj = { file_path: SAMPLE_FILE, ranges: [{ start: 100, end: 115 }] };
   const targeted = await handleRead({
     file_path: SAMPLE_FILE,
@@ -366,7 +364,6 @@ async function truelineMultiRegion(): Promise<ScenarioResult> {
       { start: 200, end: 220 },
       { start: 400, end: 420 },
     ],
-    hashes: false,
   };
   const read = await handleRead({
     file_path: SAMPLE_FILE,
@@ -375,7 +372,6 @@ async function truelineMultiRegion(): Promise<ScenarioResult> {
       { start: 200, end: 220 },
       { start: 400, end: 420 },
     ],
-    hashes: false,
     projectDir: PROJECT_DIR,
     allowedDirs: ALLOWED_DIRS,
   });

--- a/configs/codex/AGENTS.md
+++ b/configs/codex/AGENTS.md
@@ -6,7 +6,7 @@ built-in file operations.
 
 ## Tools
 
-- **trueline_read** — Read a file with per-line hashes and range checksums. Call before editing.
+- **trueline_read** — Read a file with range checksums. Call before editing.
 - **trueline_edit** — Apply hash-verified edits. Each edit needs a checksum from trueline_read.
 - **trueline_diff** — Preview edits as a unified diff without writing to disk.
 - **trueline_outline** — Get a compact structural outline of a source file.

--- a/configs/gemini-cli/GEMINI.md
+++ b/configs/gemini-cli/GEMINI.md
@@ -6,7 +6,7 @@ built-in file operations.
 
 ## Tools
 
-- **trueline_read** — Read a file with per-line hashes and range checksums. Call before editing.
+- **trueline_read** — Read a file with range checksums. Call before editing.
 - **trueline_edit** — Apply hash-verified edits. Each edit needs a checksum from trueline_read.
 - **trueline_diff** — Preview edits as a unified diff without writing to disk.
 - **trueline_outline** — Get a compact structural outline of a source file.

--- a/configs/opencode/AGENTS.md
+++ b/configs/opencode/AGENTS.md
@@ -6,7 +6,7 @@ built-in file operations.
 
 ## Tools
 
-- **trueline_read** — Read a file with per-line hashes and range checksums. Call before editing.
+- **trueline_read** — Read a file with range checksums. Call before editing.
 - **trueline_edit** — Apply hash-verified edits. Each edit needs a checksum from trueline_read.
 - **trueline_diff** — Preview edits as a unified diff without writing to disk.
 - **trueline_outline** — Get a compact structural outline of a source file.

--- a/configs/vscode-copilot/copilot-instructions.md
+++ b/configs/vscode-copilot/copilot-instructions.md
@@ -6,7 +6,7 @@ built-in file operations.
 
 ## Tools
 
-- **trueline_read** — Read a file with per-line hashes and range checksums. Call before editing.
+- **trueline_read** — Read a file with range checksums. Call before editing.
 - **trueline_edit** — Apply hash-verified edits. Each edit needs a checksum from trueline_read.
 - **trueline_diff** — Preview edits as a unified diff without writing to disk.
 - **trueline_outline** — Get a compact structural outline of a source file.

--- a/hooks/core/instructions.js
+++ b/hooks/core/instructions.js
@@ -64,24 +64,24 @@ export function getInstructions(platform = "claude-code") {
   <tools>
     <tool name="trueline_outline">Structural outline of one or more files. Returns functions, classes, and declarations with line ranges. Always cheaper than reading the full file.</tool>
     <tool name="trueline_diff">Semantic AST-based diff vs a git ref. Pass all files in one call via file_paths; use ["*"] for all changed files. No built-in equivalent.</tool>
-    <tool name="trueline_read">Read files with per-line hashes. Pass hashes=false when you only need to understand code, not edit it.</tool>
-    <tool name="trueline_edit">Hash-verified edits. Needs checksum from trueline_read or trueline_search. Pass dry_run=true to preview as unified diff.</tool>
-    <tool name="trueline_search">Literal string search with hashes \u2014 returns edit-ready results. Set regex=true for regex. Use for single-file searches when you plan to edit the matches.</tool>
+    <tool name="trueline_read">Read files with checksums. Returns line content with range checksums for editing.</tool>
+    <tool name="trueline_edit">Checksum-verified edits. Needs checksum from trueline_read or trueline_search. Pass dry_run=true to preview as unified diff.</tool>
+    <tool name="trueline_search">Literal string search \u2014 returns edit-ready results with checksums. Set regex=true for regex. Use for single-file searches when you plan to edit the matches.</tool>
     <tool name="trueline_verify">Check if held checksums are still valid. Cheaper than re-reading.</tool>
   </tools>
   <exploration>
-    <rule>To understand a file's structure, use trueline_outline instead of ${p.readTool}. Outline returns ~10-20 lines for a typical file vs hundreds from a full read. This applies to all files, not just large ones.</rule>
+    <rule>To understand a file's structure, use trueline_outline instead of ${p.readTool}. Outline returns ~10-20 lines for a typical file vs hundreds from a full read.</rule>
     <rule>To review changes, use trueline_diff. It provides a semantic summary of structural changes (added/removed/renamed symbols, signature changes) that no built-in tool can produce.</rule>
     <rule>Only use ${p.readTool} for files you need to see in full (short configs, READMEs, files under ~50 lines).</rule>
   </exploration>
   <editing>
-    <path name="surgical" default="true">When you know the target (a function name, variable, string): use trueline_search to find lines with verification hashes, then trueline_edit. This is the fastest path and guarantees edits land on the right content.</path>
-    <path name="exploratory">When you need context first: trueline_outline \u2192 trueline_read (targeted ranges, hashes=false) to understand, then trueline_search or trueline_read (with hashes) \u2192 trueline_edit.</path>
+    <path name="surgical" default="true">When you know the target (a function name, variable, string): use trueline_search to find lines with checksums, then trueline_edit. This is the fastest path and guarantees edits land on the right content.</path>
+    <path name="exploratory">When you need context first: trueline_outline \u2192 trueline_read (targeted ranges) to understand, then trueline_search or trueline_read \u2192 trueline_edit.</path>
     <path name="small-edit">For files under ~200 lines or trivial one-line changes: ${p.readTool} and ${p.editTool} are fine. The MCP round-trip overhead outweighs hash verification savings on small files.</path>
   </editing>
   <workflow>trueline_outline \u2192 understand structure (any file, any size)</workflow>
   <workflow>trueline_search \u2192 trueline_edit (fastest edit path, no read needed)</workflow>
-  <workflow>trueline_outline \u2192 trueline_read (targeted ranges) \u2192 trueline_edit</workflow>
+  <workflow>trueline_outline \u2192 trueline_read (targeted ranges) \u2192 trueline_edit (exploratory path)</workflow>
   <workflow>trueline_verify \u2192 trueline_read (re-read only stale ranges) \u2192 trueline_edit</workflow>
   <workflow>trueline_diff \u2192 review structural changes vs git state</workflow>${deferredHint}
 

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -88,27 +88,3 @@ export function foldHash(accumulator: number, h: number): number {
 export function formatChecksum(startLine: number, endLine: number, hash: number): string {
   return `${startLine}-${endLine}:${hash.toString(16).padStart(8, "0")}`;
 }
-
-/**
- * 26-char alphabet: lowercase a-z only.
- * Fewer combinations (676) than the prior base32 alphabet (1024),
- * but LLMs transcribe pure-letter hashes more reliably.
- */
-const HASH_CHARS = "abcdefghijklmnopqrstuvwxyz";
-
-/**
- * Pre-computed lookup table of all 676 two-character hash tags.
- * Avoids per-call string concatenation in the hot loop.
- */
-const LETTER_TABLE: string[] = /* @__PURE__ */ (() => {
-  const t = new Array<string>(676);
-  for (let i = 0; i < 26; i++) for (let j = 0; j < 26; j++) t[i * 26 + j] = HASH_CHARS[i] + HASH_CHARS[j];
-  return t;
-})();
-
-/**
- * Map an FNV-1a hash to a two-character tag (676 possible values).
- */
-export function hashToLetters(h: number): string {
-  return LETTER_TABLE[((h >>> 0) % 26) * 26 + (((h >>> 8) >>> 0) % 26)];
-}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,57 +4,30 @@
 
 const DECIMAL_INT = /^\d+$/;
 
-interface LineRef {
-  line: number;
-  hash: string;
-}
-
-/**
- * Parse a `line:hash` reference string like "4:mp".
- *
- * Special case: "0:" is valid (insert at file start, empty hash).
- * Throws on invalid format.
- */
-function parseLineHash(ref: string): LineRef {
-  const colonIdx = ref.indexOf(":");
-  if (colonIdx === -1) {
-    throw new Error(`Invalid line:hash reference "${ref}" — missing colon`);
-  }
-
-  const lineStr = ref.slice(0, colonIdx);
-  const hash = ref.slice(colonIdx + 1);
-
-  // Reject non-decimal strings before Number() conversion — without this,
-  // Number("") === 0 and Number(" ") === 0 would silently parse as line 0.
-  if (!DECIMAL_INT.test(lineStr)) {
-    throw new Error(`Invalid line number in "${ref}" — must be a non-negative integer`);
-  }
-
-  const line = Number(lineStr);
-
-  if (line === 0 && hash !== "") {
-    throw new Error(`Invalid line:hash reference "${ref}" — line 0 must have empty hash`);
-  }
-  if (line > 0 && !/^[a-z]{2}$/.test(hash)) {
-    throw new Error(`Invalid hash in "${ref}" — must be exactly 2 lowercase letters`);
-  }
-
-  return { line, hash };
-}
-
 interface RangeRef {
-  start: LineRef;
-  end: LineRef;
+  start: number;
+  end: number;
   insertAfter: boolean;
 }
 
 /**
- * Parse a range string into start/end LineRefs.
+ * Parse a line number string, validating it's a non-negative decimal integer.
+ * Throws on invalid format.
+ */
+function parseLineNumber(s: string): number {
+  if (!DECIMAL_INT.test(s)) {
+    throw new Error(`Invalid line number "${s}" — must be a non-negative integer`);
+  }
+  return Number(s);
+}
+
+/**
+ * Parse a range string into start/end line numbers.
  *
  * Accepts three forms:
- *   - "12:gh-21:yz"  — explicit start-end range (replace)
- *   - "5:ab"          — single-line shorthand, equivalent to "5:ab-5:ab"
- *   - "+5:ab"         — insert-after line 5 (single-line only)
+ *   - "12-21"   — explicit start-end range (replace)
+ *   - "5"       — single-line shorthand, equivalent to "5-5"
+ *   - "+5"      — insert-after line 5 (single-line only)
  *
  * The `+` prefix signals insert-after and is only valid on single-line
  * ranges (no `-`). Throws on invalid format or if start line > end line.
@@ -68,8 +41,6 @@ export function parseRange(range: string): RangeRef {
     raw = raw.slice(1);
   }
 
-  // Find "-" separator between two line:hash refs. Since neither line numbers
-  // (digits) nor hashes ([a-z]{2}) contain "-", indexOf is unambiguous.
   const dashIdx = raw.indexOf("-");
 
   if (insertAfter && dashIdx !== -1) {
@@ -77,15 +48,15 @@ export function parseRange(range: string): RangeRef {
   }
 
   if (dashIdx === -1) {
-    const ref = parseLineHash(raw);
-    return { start: ref, end: { ...ref }, insertAfter };
+    const line = parseLineNumber(raw);
+    return { start: line, end: line, insertAfter };
   }
 
-  const start = parseLineHash(raw.slice(0, dashIdx));
-  const end = parseLineHash(raw.slice(dashIdx + 1));
+  const start = parseLineNumber(raw.slice(0, dashIdx));
+  const end = parseLineNumber(raw.slice(dashIdx + 1));
 
-  if (start.line > end.line) {
-    throw new Error(`Invalid range "${range}" — start line ${start.line} must be ≤ end line ${end.line}`);
+  if (start > end) {
+    throw new Error(`Invalid range "${range}" — start line ${start} must be ≤ end line ${end}`);
   }
 
   return { start, end, insertAfter };

--- a/src/server.ts
+++ b/src/server.ts
@@ -72,7 +72,7 @@ server.registerTool(
   "trueline_read",
   {
     description:
-      'Read a file. Requires file_path. Example: {"file_path": "src/main.ts", "ranges": ["10-25"]}. Returns per-line hashes and checksums for editing.',
+      'Read a file. Requires file_path. Example: {"file_path": "src/main.ts", "ranges": ["10-25"]}. Returns line content with checksums for editing.',
     inputSchema: z.preprocess(
       coerceParams,
       z.object({
@@ -86,12 +86,6 @@ server.registerTool(
           )
           .optional(),
         encoding: z.string().describe("File encoding. Defaults to utf-8. Supported: utf-8, ascii, latin1.").optional(),
-        hashes: z
-          .boolean()
-          .describe(
-            "Include per-line hashes in output. Defaults to true. Set to false for exploratory reads where you don't plan to edit — saves tokens. Checksums are always included.",
-          )
-          .optional(),
       }),
     ),
   },
@@ -118,7 +112,7 @@ server.registerTool(
                 .describe(
                   "Checksum from trueline_read or trueline_search whose line range covers this edit's target lines",
                 ),
-              range: z.string().describe("startLine:hash-endLine:hash or startLine:hash; prefix + for insert-after"),
+              range: z.string().describe("startLine-endLine or startLine; prefix + for insert-after"),
 
               content: z.string().describe("Replacement lines, newline-separated. Empty string to delete."),
             }),
@@ -193,7 +187,7 @@ server.registerTool(
   "trueline_search",
   {
     description:
-      "Search a file for a literal string or regex pattern. Returns matching lines with context, per-line hashes, and checksums \u2014 " +
+      "Search a file for a literal string or regex pattern. Returns matching lines with context and checksums \u2014 " +
       "ready for immediate editing. Use instead of outline+read when you know what to look for.",
     inputSchema: z.preprocess(
       coerceParams,

--- a/src/streaming-edit.ts
+++ b/src/streaming-edit.ts
@@ -23,14 +23,7 @@
 import { randomBytes } from "node:crypto";
 import { chmod, open, rename, stat, unlink } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import {
-  EMPTY_FILE_CHECKSUM,
-  FNV_OFFSET_BASIS,
-  fnv1aHashBytes,
-  foldHash,
-  formatChecksum,
-  hashToLetters,
-} from "./hash.ts";
+import { EMPTY_FILE_CHECKSUM, FNV_OFFSET_BASIS, fnv1aHashBytes, foldHash, formatChecksum } from "./hash.ts";
 import { EMPTY_BUF, LF_BUF, splitLines } from "./line-splitter.ts";
 import type { DiffCollector } from "./diff-collector.ts";
 import type { ChecksumRef } from "./parse.ts";
@@ -44,8 +37,6 @@ export interface StreamEditOp {
   endLine: number;
   content: string[];
   insertAfter: boolean;
-  startHash: string;
-  endHash: string;
 }
 
 // ==============================================================================
@@ -235,10 +226,6 @@ export async function streamingEdit(
     return outputLineCount > 0 ? formatChecksum(1, outputLineCount, outputChecksumAcc) : EMPTY_FILE_CHECKSUM;
   }
 
-  function hashMismatchMsg(lineNumber: number, expected: string, got: string): string {
-    return `hash mismatch at line ${lineNumber}: expected ${expected}, got ${got}`;
-  }
-
   // ---- Handle line-0 insert_after (prepend) before streaming ----
   const line0Ops = opsByStartLine.get(0);
   if (line0Ops) {
@@ -262,9 +249,8 @@ export async function streamingEdit(
         eolDetected = true;
       }
 
-      // Compute line hash for checksum accumulators and boundary verification
+      // Compute line hash for checksum accumulators
       const lineH = fnv1aHashBytes(lineBytes, 0, lineBytes.length);
-      const letters = hashToLetters(lineH);
 
       // Feed into checksum accumulators
       while (csIdx < csAccumulators.length) {
@@ -282,13 +268,6 @@ export async function streamingEdit(
 
       // Check if we're inside an active replace range (skipping lines)
       if (activeReplace && lineNumber <= activeReplace.endLine) {
-        // Verify end boundary hash
-        if (lineNumber === activeReplace.endLine && activeReplace.endHash !== "") {
-          if (letters !== activeReplace.endHash) {
-            return await fail(hashMismatchMsg(lineNumber, activeReplace.endHash, letters));
-          }
-        }
-
         activeReplaceOrigBytes.push(lineBytes);
 
         // End of replace range: write replacement content
@@ -331,11 +310,6 @@ export async function streamingEdit(
         }
 
         if (replaceOp) {
-          // Verify start boundary hash
-          if (replaceOp.startHash !== "" && letters !== replaceOp.startHash) {
-            return await fail(hashMismatchMsg(lineNumber, replaceOp.startHash, letters));
-          }
-
           if (replaceOp.startLine === replaceOp.endLine) {
             // Single-line replace: handle immediately
             await writeReplaceOrOriginal(replaceOp, [lineBytes]);
@@ -350,21 +324,9 @@ export async function streamingEdit(
             // Multi-line replace: enter active replace mode
             activeReplace = replaceOp;
             activeReplaceOrigBytes = [lineBytes];
-
-            // Verify start boundary hash for the end line too (done when we reach it)
-            // insert_after ops at endLine will be handled when we reach it
-            // But insert_after ops at startLine that aren't the end? Not meaningful
-            // for multi-line replace starting at startLine.
           }
         } else {
           // No replace op — just write the line and process insert_after
-          // Verify boundary hash for insert_after ops
-          for (const iaOp of insertOps) {
-            if (iaOp.startHash !== "" && letters !== iaOp.startHash) {
-              return await fail(hashMismatchMsg(lineNumber, iaOp.startHash, letters));
-            }
-          }
-
           await enqueueLine(lineBytes, lineH);
           if (collector) collector.context(lineBytes.toString(encoding));
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -11,14 +11,7 @@
 // ==============================================================================
 
 import { splitLines, LF_BUF } from "../line-splitter.ts";
-import {
-  EMPTY_FILE_CHECKSUM,
-  FNV_OFFSET_BASIS,
-  fnv1aHashBytes,
-  foldHash,
-  formatChecksum,
-  hashToLetters,
-} from "../hash.ts";
+import { EMPTY_FILE_CHECKSUM, FNV_OFFSET_BASIS, fnv1aHashBytes, foldHash, formatChecksum } from "../hash.ts";
 import { parseRanges, type ReadRange } from "../parse.ts";
 import { validateEncoding, validatePath } from "./shared.ts";
 import { errorResult, type ToolResult, textResult } from "./types.ts";
@@ -26,7 +19,6 @@ import { errorResult, type ToolResult, textResult } from "./types.ts";
 interface ReadParams {
   file_path: string;
   encoding?: string;
-  hashes?: boolean;
   ranges?: string[];
   projectDir?: string;
   allowedDirs?: string[];
@@ -34,7 +26,6 @@ interface ReadParams {
 
 export async function handleRead(params: ReadParams): Promise<ToolResult> {
   const { file_path, projectDir, allowedDirs } = params;
-  const includeHashes = params.hashes !== false;
 
   const validated = await validatePath(file_path, "Read", projectDir, allowedDirs);
   if (!validated.ok) return validated.error;
@@ -101,9 +92,7 @@ export async function handleRead(params: ReadParams): Promise<ToolResult> {
       if (rangeFirstLine === 0) rangeFirstLine = lineNumber;
 
       const h = fnv1aHashBytes(lineBytes, 0, lineBytes.length);
-      const prefix = includeHashes
-        ? Buffer.from(`${lineNumber}:${hashToLetters(h)}	`)
-        : Buffer.from(`${lineNumber}	`);
+      const prefix = Buffer.from(`${lineNumber}\t`);
       const lineLen = prefix.length + lineBytes.length + 1;
 
       // Check output limits before committing this line

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,14 +1,14 @@
 /**
  * trueline_search tool handler.
  *
- * Searches a file by regex and returns matching lines with context,
- * per-line hashes, and checksums — ready for immediate editing.
+ * Searches a file by regex and returns matching lines with context
+ * and checksums — ready for immediate editing.
  *
  * Uses a single-pass sliding window so memory is O(contextLines) instead
  * of O(file_size). Decodes each line to a string exactly once.
  */
 import { splitLines } from "../line-splitter.ts";
-import { fnv1aHashBytes, hashToLetters, foldHash, FNV_OFFSET_BASIS, formatChecksum } from "../hash.ts";
+import { fnv1aHashBytes, foldHash, FNV_OFFSET_BASIS, formatChecksum } from "../hash.ts";
 import { validatePath } from "./shared.ts";
 import { errorResult, textResult, type ToolResult } from "./types.ts";
 
@@ -204,7 +204,7 @@ export async function handleSearch(params: SearchParams): Promise<ToolResult> {
   }
 
   // ===========================================================================
-  // Format output with hashes and checksums
+  // Format output with checksums
   // ===========================================================================
 
   const parts: string[] = [];
@@ -223,7 +223,7 @@ export async function handleSearch(params: SearchParams): Promise<ToolResult> {
       checksumHash = foldHash(checksumHash, line.hash);
 
       const marker = line.isMatch ? "  ← match" : "";
-      parts.push(`${line.lineNumber}:${hashToLetters(line.hash)}	${line.text}${marker}`);
+      parts.push(`${line.lineNumber}\t${line.text}${marker}`);
     }
 
     parts.push("");

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -124,7 +124,7 @@ type ValidateEditsResult = ValidateEditsOk | ValidateEditsErr;
  *
  * Performs range parsing, line-0 constraints, checksum-range coverage,
  * and overlap detection. File-content verification (checksum match,
- * boundary hash match) is deferred to the streaming pass.
+ * checksum match) is deferred to the streaming pass.
  */
 export function validateEdits(edits: EditInput[]): ValidateEditsResult {
   const ops: StreamEditOp[] = [];
@@ -137,21 +137,21 @@ export function validateEdits(edits: EditInput[]): ValidateEditsResult {
     const rangeRef = parseRange(edit.range);
 
     // line 0 only valid for insert-after (encoded as + prefix in range)
-    if (rangeRef.start.line === 0 && !rangeRef.insertAfter) {
+    if (rangeRef.start === 0 && !rangeRef.insertAfter) {
       return {
         ok: false,
-        error: errorResult("range starting at line 0 requires insert-after (use +0: prefix)"),
+        error: errorResult("range starting at line 0 requires insert-after (use +0 prefix)"),
       };
     }
 
     // Verify checksum range covers edit target
-    if (rangeRef.start.line > 0) {
-      if (checksumRef.startLine > rangeRef.start.line || checksumRef.endLine < rangeRef.end.line) {
+    if (rangeRef.start > 0) {
+      if (checksumRef.startLine > rangeRef.start || checksumRef.endLine < rangeRef.end) {
         return {
           ok: false,
           error: errorResult(
             `Checksum range ${checksumRef.startLine}-${checksumRef.endLine} does not cover ` +
-              `edit range ${rangeRef.start.line}-${rangeRef.end.line}. ` +
+              `edit range ${rangeRef.start}-${rangeRef.end}. ` +
               `Re-read with trueline_read to get a checksum covering the target lines.`,
           ),
         };
@@ -159,12 +159,10 @@ export function validateEdits(edits: EditInput[]): ValidateEditsResult {
     }
 
     ops.push({
-      startLine: rangeRef.start.line,
-      endLine: rangeRef.end.line,
+      startLine: rangeRef.start,
+      endLine: rangeRef.end,
       content: edit.content === "" ? [] : edit.content.split("\n"),
       insertAfter: rangeRef.insertAfter,
-      startHash: rangeRef.start.hash,
-      endHash: rangeRef.end.hash,
     });
   }
 

--- a/tests/coerce.test.ts
+++ b/tests/coerce.test.ts
@@ -65,16 +65,16 @@ describe("coerceParams", () => {
 
   describe("boolean coercion", () => {
     test('coerces "true" → true', () => {
-      expect(coerceParams({ hashes: "true" })).toEqual({ hashes: true });
+      expect(coerceParams({ dry_run: "true" })).toEqual({ dry_run: true });
     });
 
     test('coerces "false" → false', () => {
-      expect(coerceParams({ hashes: "false" })).toEqual({ hashes: false });
+      expect(coerceParams({ dry_run: "false" })).toEqual({ dry_run: false });
     });
 
     test("leaves actual booleans unchanged", () => {
-      expect(coerceParams({ hashes: true })).toEqual({ hashes: true });
-      expect(coerceParams({ hashes: false })).toEqual({ hashes: false });
+      expect(coerceParams({ dry_run: true })).toEqual({ dry_run: true });
+      expect(coerceParams({ dry_run: false })).toEqual({ dry_run: false });
     });
   });
 
@@ -94,10 +94,9 @@ describe("coerceParams", () => {
     });
 
     test("realistic trueline_read call with string ranges", () => {
-      expect(coerceParams({ file_path: "src/server.ts", ranges: ["149-173"], hashes: "false" })).toEqual({
+      expect(coerceParams({ file_path: "src/server.ts", ranges: ["149-173"] })).toEqual({
         file_path: "src/server.ts",
         ranges: ["149-173"],
-        hashes: false,
       });
     });
   });
@@ -108,7 +107,7 @@ describe("coerceParams", () => {
     });
 
     test("alias + boolean coercion together", () => {
-      expect(coerceParams({ path: "a.ts", hashes: "false" })).toEqual({ file_path: "a.ts", hashes: false });
+      expect(coerceParams({ path: "a.ts", dry_run: "false" })).toEqual({ file_path: "a.ts", dry_run: false });
     });
 
     test("realistic trueline_outline call with paths alias", () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { FNV_OFFSET_BASIS, fnv1aHashBytes, foldHash, fnv1aHash, formatChecksum, hashToLetters } from "../src/hash.ts";
+import { FNV_OFFSET_BASIS, fnv1aHashBytes, foldHash, fnv1aHash, formatChecksum } from "../src/hash.ts";
 
 /**
  * Compute a read-range checksum over a slice of file lines.
@@ -17,15 +17,6 @@ export function rangeChecksum(lines: string[], startLine: number, endLine: numbe
 }
 
 /**
- * Compute 2-character content hash for a line.
- *
- * Maps FNV-1a output to a two-character tag via `hashToLetters`.
- */
-export function lineHash(line: string): string {
-  return hashToLetters(fnv1aHash(line));
-}
-
-/**
  * Compute a read-range checksum over raw byte buffers.
  *
  * Use this for non-UTF-8 test files where the raw bytes differ from
@@ -37,12 +28,4 @@ export function rawRangeChecksum(bufs: Buffer[], startLine: number, endLine: num
     hash = foldHash(hash, fnv1aHashBytes(bufs[i], 0, bufs[i].length));
   }
   return formatChecksum(startLine, endLine, hash);
-}
-
-/**
- * Compute 2-letter content hash from raw bytes.
- */
-export function rawLineHash(buf: Buffer): string {
-  const h = fnv1aHashBytes(buf, 0, buf.length);
-  return hashToLetters(h);
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -33,11 +33,6 @@ describe("read → diff → edit roundtrip", () => {
     expect(checksumMatch).not.toBeNull();
     const checksum = checksumMatch![1];
 
-    // Extract line 2 hash from read result
-    const line2Match = readText.match(/^2:([a-z]{2})\t/m);
-    expect(line2Match).not.toBeNull();
-    const line2Hash = line2Match![1];
-
     // Step 2: Preview the edit with dry_run
     const diffResult = await handleEdit({
       file_path: testFile,
@@ -45,7 +40,7 @@ describe("read → diff → edit roundtrip", () => {
       edits: [
         {
           checksum,
-          range: `2:${line2Hash}-2:${line2Hash}`,
+          range: "2-2",
           // biome-ignore lint/suspicious/noTemplateCurlyInString: test content is source code with template literals
           content: "  return `Hello, ${name}!`;",
         },
@@ -67,7 +62,7 @@ describe("read → diff → edit roundtrip", () => {
       edits: [
         {
           checksum,
-          range: `2:${line2Hash}-2:${line2Hash}`,
+          range: "2-2",
           // biome-ignore lint/suspicious/noTemplateCurlyInString: test content is source code with template literals
           content: "  return `Hello, ${name}!`;",
         },
@@ -82,7 +77,7 @@ describe("read → diff → edit roundtrip", () => {
     expect(afterEdit).toContain("`Hello, ${name}!`");
     expect(afterEdit).not.toContain('"Hello, " + name');
 
-    // Step 5: Re-read and verify new hashes work
+    // Step 5: Re-read and verify new checksums work
     const rereadResult = await handleRead({
       file_path: testFile,
       projectDir: testDir,

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -73,25 +73,25 @@ describe("parseRanges", () => {
 
 describe("parseRange", () => {
   test("parses dash-separated range", () => {
-    const result = parseRange("16:kq-17:yx");
-    expect(result.start).toEqual({ line: 16, hash: "kq" });
-    expect(result.end).toEqual({ line: 17, hash: "yx" });
+    const result = parseRange("16-17");
+    expect(result.start).toBe(16);
+    expect(result.end).toBe(17);
     expect(result.insertAfter).toBe(false);
   });
 
   test("parses single line reference", () => {
-    const result = parseRange("5:ab");
-    expect(result.start).toEqual({ line: 5, hash: "ab" });
-    expect(result.end).toEqual({ line: 5, hash: "ab" });
+    const result = parseRange("5");
+    expect(result.start).toBe(5);
+    expect(result.end).toBe(5);
   });
 
   test("parses insert-after prefix", () => {
-    const result = parseRange("+10:cd");
+    const result = parseRange("+10");
     expect(result.insertAfter).toBe(true);
-    expect(result.start).toEqual({ line: 10, hash: "cd" });
+    expect(result.start).toBe(10);
   });
 
   test("rejects insert-after with range", () => {
-    expect(() => parseRange("+10:cd-20:ef")).toThrow(/insert-after/);
+    expect(() => parseRange("+10-20")).toThrow(/insert-after/);
   });
 });

--- a/tests/streaming-edit.test.ts
+++ b/tests/streaming-edit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, realpathSync, writeFileSync, readFileSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { lineHash, rangeChecksum } from "./helpers.ts";
+import { rangeChecksum } from "./helpers.ts";
 import { type EditInput, validateEdits } from "../src/tools/shared.ts";
 import { streamingEdit } from "../src/streaming-edit.ts";
 
@@ -18,34 +18,32 @@ afterEach(() => {
 
 describe("validateEdits", () => {
   test("accepts valid single replace edit", () => {
-    const result = validateEdits([{ checksum: "1-4:abcdef01", range: "2:ab-3:cd", content: "x\ny" }]);
+    const result = validateEdits([{ checksum: "1-4:abcdef01", range: "2-3", content: "x\ny" }]);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.ops).toHaveLength(1);
       expect(result.ops[0].startLine).toBe(2);
       expect(result.ops[0].endLine).toBe(3);
-      expect(result.ops[0].startHash).toBe("ab");
-      expect(result.ops[0].endHash).toBe("cd");
       expect(result.checksumRefs[0].startLine).toBe(1);
       expect(result.checksumRefs[0].endLine).toBe(4);
     }
   });
 
   test("accepts valid insert_after at line 0", () => {
-    const result = validateEdits([{ checksum: "0-0:00000000", range: "+0:", content: "new" }]);
+    const result = validateEdits([{ checksum: "0-0:00000000", range: "+0", content: "new" }]);
     expect(result.ok).toBe(true);
   });
 
   test("rejects line 0 without insert_after", () => {
-    const result = validateEdits([{ checksum: "0-0:00000000", range: "0:", content: "x" }]);
+    const result = validateEdits([{ checksum: "0-0:00000000", range: "0", content: "x" }]);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.content[0].text).toContain("insert-after (use +0: prefix)");
+      expect(result.error.content[0].text).toContain("insert-after (use +0 prefix)");
     }
   });
 
   test("rejects checksum that does not cover edit range", () => {
-    const result = validateEdits([{ checksum: "1-2:abcdef01", range: "4:ab-4:ab", content: "x" }]);
+    const result = validateEdits([{ checksum: "1-2:abcdef01", range: "4-4", content: "x" }]);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.content[0].text).toContain("does not cover");
@@ -54,8 +52,8 @@ describe("validateEdits", () => {
 
   test("rejects overlapping replace ranges", () => {
     const result = validateEdits([
-      { checksum: "1-4:abcdef01", range: "1:aa-2:bb", content: "A" },
-      { checksum: "1-4:abcdef01", range: "2:bb-2:bb", content: "B" },
+      { checksum: "1-4:abcdef01", range: "1-2", content: "A" },
+      { checksum: "1-4:abcdef01", range: "2-2", content: "B" },
     ]);
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -65,8 +63,8 @@ describe("validateEdits", () => {
 
   test("allows insert_after ops at same anchor (no overlap)", () => {
     const result = validateEdits([
-      { checksum: "1-4:abcdef01", range: "+1:aa", content: "A" },
-      { checksum: "1-4:abcdef01", range: "+1:aa", content: "B" },
+      { checksum: "1-4:abcdef01", range: "+1", content: "A" },
+      { checksum: "1-4:abcdef01", range: "+1", content: "B" },
     ]);
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -77,8 +75,8 @@ describe("validateEdits", () => {
   test("rejects insert-after inside a replace range", () => {
     // Replace covers lines 2-4, insert-after at line 3 is ambiguous
     const result = validateEdits([
-      { checksum: "1-5:abcdef01", range: "2:aa-4:bb", content: "A\nB\nC" },
-      { checksum: "1-5:abcdef01", range: "+3:cc", content: "inserted" },
+      { checksum: "1-5:abcdef01", range: "2-4", content: "A\nB\nC" },
+      { checksum: "1-5:abcdef01", range: "+3", content: "inserted" },
     ]);
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -89,8 +87,8 @@ describe("validateEdits", () => {
   test("allows insert-after at end of replace range (not inside)", () => {
     // Replace covers lines 2-4, insert-after at line 4 is at the boundary
     const result = validateEdits([
-      { checksum: "1-5:abcdef01", range: "2:aa-4:bb", content: "A\nB\nC" },
-      { checksum: "1-5:abcdef01", range: "+4:bb", content: "after replace" },
+      { checksum: "1-5:abcdef01", range: "2-4", content: "A\nB\nC" },
+      { checksum: "1-5:abcdef01", range: "+4", content: "after replace" },
     ]);
     expect(result.ok).toBe(true);
   });
@@ -119,9 +117,8 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\n");
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h2 = lineHash("line 2");
 
-    const result = await runEdit(f, [{ range: `2:${h2}`, content: "replaced" }], cs);
+    const result = await runEdit(f, [{ range: `2`, content: "replaced" }], cs);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.changed).toBe(true);
     expect(readFileSync(f, "utf-8")).toBe("line 1\nreplaced\nline 3\n");
@@ -132,10 +129,8 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\nline 4\n");
     const lines = ["line 1", "line 2", "line 3", "line 4"];
     const cs = rangeChecksum(lines, 1, 4);
-    const h2 = lineHash("line 2");
-    const h3 = lineHash("line 3");
 
-    const result = await runEdit(f, [{ range: `2:${h2}-3:${h3}`, content: "replaced 2\nreplaced 3" }], cs);
+    const result = await runEdit(f, [{ range: `2-3`, content: "replaced 2\nreplaced 3" }], cs);
     expect(result.ok).toBe(true);
     expect(readFileSync(f, "utf-8")).toBe("line 1\nreplaced 2\nreplaced 3\nline 4\n");
   });
@@ -145,9 +140,8 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\n");
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h2 = lineHash("line 2");
 
-    const result = await runEdit(f, [{ range: `2:${h2}`, content: "" }], cs);
+    const result = await runEdit(f, [{ range: `2`, content: "" }], cs);
     expect(result.ok).toBe(true);
     expect(readFileSync(f, "utf-8")).toBe("line 1\nline 3\n");
   });
@@ -157,9 +151,8 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\n");
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h2 = lineHash("line 2");
 
-    const result = await runEdit(f, [{ range: `2:${h2}`, content: "replaced" }], cs);
+    const result = await runEdit(f, [{ range: `2`, content: "replaced" }], cs);
     if (!result.ok) return;
 
     const newLines = ["line 1", "replaced", "line 3"];
@@ -176,9 +169,8 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\n");
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h1 = lineHash("line 1");
 
-    const result = await runEdit(f, [{ range: `+1:${h1}`, content: "inserted" }], cs);
+    const result = await runEdit(f, [{ range: `+1`, content: "inserted" }], cs);
     expect(result.ok).toBe(true);
     expect(readFileSync(f, "utf-8")).toBe("line 1\ninserted\nline 2\nline 3\n");
   });
@@ -188,14 +180,13 @@ describe("streamingEdit", () => {
     writeFileSync(f, "anchor\nnext\n");
     const lines = ["anchor", "next"];
     const cs = rangeChecksum(lines, 1, 2);
-    const h = lineHash("anchor");
 
     const result = await runEdit(
       f,
       [
-        { range: `+1:${h}`, content: "first" },
-        { range: `+1:${h}`, content: "second" },
-        { range: `+1:${h}`, content: "third" },
+        { range: `+1`, content: "first" },
+        { range: `+1`, content: "second" },
+        { range: `+1`, content: "third" },
       ],
       cs,
     );
@@ -209,7 +200,7 @@ describe("streamingEdit", () => {
     const lines = ["existing"];
     const cs = rangeChecksum(lines, 1, 1);
 
-    const result = await runEdit(f, [{ range: "+0:", content: "prepended" }], cs);
+    const result = await runEdit(f, [{ range: "+0", content: "prepended" }], cs);
     expect(result.ok).toBe(true);
     expect(readFileSync(f, "utf-8")).toBe("prepended\nexisting\n");
   });
@@ -223,14 +214,12 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\nline 4\n");
     const lines = ["line 1", "line 2", "line 3", "line 4"];
     const cs = rangeChecksum(lines, 1, 4);
-    const h1 = lineHash("line 1");
-    const h4 = lineHash("line 4");
 
     const result = await runEdit(
       f,
       [
-        { range: `1:${h1}`, content: "A" },
-        { range: `4:${h4}`, content: "D" },
+        { range: `1`, content: "A" },
+        { range: `4`, content: "D" },
       ],
       cs,
     );
@@ -243,14 +232,12 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\n");
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h1 = lineHash("line 1");
-    const h3 = lineHash("line 3");
 
     const result = await runEdit(
       f,
       [
-        { range: `1:${h1}`, content: "A" },
-        { range: `+3:${h3}`, content: "inserted" },
+        { range: `1`, content: "A" },
+        { range: `+3`, content: "inserted" },
       ],
       cs,
     );
@@ -267,22 +254,7 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2\nline 3\n");
     const { mtimeMs } = statSync(f);
 
-    const validated = validateEdits([{ checksum: "1-3:00000000", range: "1:aa-1:aa", content: "nope" }]);
-    if (!validated.ok) return;
-
-    const result = await streamingEdit(f, validated.ops, validated.checksumRefs, mtimeMs);
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toContain("mismatch");
-  });
-
-  test("rejects wrong line hash at boundary", async () => {
-    const f = join(testDir, "bad-hash.txt");
-    writeFileSync(f, "line 1\nline 2\nline 3\n");
-    const lines = ["line 1", "line 2", "line 3"];
-    const cs = rangeChecksum(lines, 1, 3);
-    const { mtimeMs } = statSync(f);
-
-    const validated = validateEdits([{ checksum: cs, range: "1:zz-1:zz", content: "nope" }]);
+    const validated = validateEdits([{ checksum: "1-3:00000000", range: "1-1", content: "nope" }]);
     if (!validated.ok) return;
 
     const result = await streamingEdit(f, validated.ops, validated.checksumRefs, mtimeMs);
@@ -294,9 +266,8 @@ describe("streamingEdit", () => {
     const f = join(testDir, "short.txt");
     writeFileSync(f, "only\n");
     const { mtimeMs } = statSync(f);
-    const h = lineHash("only");
 
-    const validated = validateEdits([{ checksum: "1-5:abcdef01", range: `1:${h}-1:${h}`, content: "x" }]);
+    const validated = validateEdits([{ checksum: "1-5:abcdef01", range: `1-1`, content: "x" }]);
     if (!validated.ok) return;
 
     const result = await streamingEdit(f, validated.ops, validated.checksumRefs, mtimeMs);
@@ -313,9 +284,8 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\r\nline 2\r\nline 3\r\n");
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h2 = lineHash("line 2");
 
-    const result = await runEdit(f, [{ range: `2:${h2}`, content: "replaced" }], cs);
+    const result = await runEdit(f, [{ range: `2`, content: "replaced" }], cs);
     expect(result.ok).toBe(true);
     const written = readFileSync(f, "utf-8");
     expect(written).toBe("line 1\r\nreplaced\r\nline 3\r\n");
@@ -327,9 +297,8 @@ describe("streamingEdit", () => {
     writeFileSync(f, "line 1\nline 2");
     const lines = ["line 1", "line 2"];
     const cs = rangeChecksum(lines, 1, 2);
-    const h1 = lineHash("line 1");
 
-    const result = await runEdit(f, [{ range: `1:${h1}`, content: "replaced" }], cs);
+    const result = await runEdit(f, [{ range: `1`, content: "replaced" }], cs);
     expect(result.ok).toBe(true);
     expect(readFileSync(f, "utf-8")).toBe("replaced\nline 2");
   });
@@ -339,7 +308,7 @@ describe("streamingEdit", () => {
     writeFileSync(f, Buffer.from([0x68, 0x65, 0x00, 0x6c, 0x6f]));
     const { mtimeMs } = statSync(f);
 
-    const validated = validateEdits([{ checksum: "1-1:abcdef01", range: "1:aa", content: "x" }]);
+    const validated = validateEdits([{ checksum: "1-1:abcdef01", range: "1", content: "x" }]);
     if (!validated.ok) return;
 
     const result = await streamingEdit(f, validated.ops, validated.checksumRefs, mtimeMs);
@@ -352,7 +321,7 @@ describe("streamingEdit", () => {
     writeFileSync(f, "");
     const { mtimeMs } = statSync(f);
 
-    const validated = validateEdits([{ checksum: "0-0:00000000", range: "+0:", content: "new content" }]);
+    const validated = validateEdits([{ checksum: "0-0:00000000", range: "+0", content: "new content" }]);
     if (!validated.ok) return;
 
     const result = await streamingEdit(f, validated.ops, validated.checksumRefs, mtimeMs);
@@ -367,7 +336,7 @@ describe("streamingEdit", () => {
     const lines = ["aaa", "bbb", "ccc"];
     const cs = rangeChecksum(lines, 1, 3);
 
-    const result = await runEdit(f, [{ range: `2:${lineHash("bbb")}`, content: "bbb" }], cs);
+    const result = await runEdit(f, [{ range: `2`, content: "bbb" }], cs);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.changed).toBe(false);
     expect(statSync(f).mtimeMs).toBe(before);
@@ -385,9 +354,8 @@ describe("streamingEdit", () => {
 
     const lines = ["line 1", "line 2"];
     const cs = rangeChecksum(lines, 1, 2);
-    const h1 = lineHash("line 1");
 
-    const validated = validateEdits([{ checksum: cs, range: `1:${h1}`, content: "changed" }]);
+    const validated = validateEdits([{ checksum: cs, range: `1`, content: "changed" }]);
     if (!validated.ok) return;
 
     const result = await streamingEdit(f, validated.ops, validated.checksumRefs, oldMtime);
@@ -401,7 +369,7 @@ describe("streamingEdit", () => {
     const { mtimeMs } = statSync(f);
 
     // Wrong checksum to trigger a mismatch error
-    const validated = validateEdits([{ checksum: "1-2:00000000", range: "1:aa-1:aa", content: "x" }]);
+    const validated = validateEdits([{ checksum: "1-2:00000000", range: "1-1", content: "x" }]);
     if (!validated.ok) return;
 
     const result = await streamingEdit(f, validated.ops, validated.checksumRefs, mtimeMs);
@@ -416,7 +384,7 @@ describe("streamingEdit", () => {
     writeFileSync(f, Buffer.from([0x68, 0x65, 0x00, 0x6c, 0x6f]));
     const { mtimeMs } = statSync(f);
 
-    const validated = validateEdits([{ checksum: "1-1:abcdef01", range: "1:aa", content: "x" }]);
+    const validated = validateEdits([{ checksum: "1-1:abcdef01", range: "1", content: "x" }]);
     if (!validated.ok) return;
 
     const result = await streamingEdit(f, validated.ops, validated.checksumRefs, mtimeMs);

--- a/tests/tools/edit-edge-cases.test.ts
+++ b/tests/tools/edit-edge-cases.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { handleEdit } from "../../src/tools/edit.ts";
 import { handleRead } from "../../src/tools/read.ts";
-import { lineHash, rangeChecksum } from "../helpers.ts";
+import { rangeChecksum } from "../helpers.ts";
 import { EMPTY_FILE_CHECKSUM } from "../../src/hash.ts";
 
 let testDir: string;
@@ -41,7 +41,7 @@ describe("single-line file edits", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("only")}`,
+          range: `1`,
           content: "replaced",
         },
       ],
@@ -60,7 +60,7 @@ describe("single-line file edits", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("only")}`,
+          range: `1`,
           content: "replaced",
         },
       ],
@@ -80,7 +80,7 @@ describe("single-line file edits", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "x1\nx2\nx3",
         },
       ],
@@ -99,7 +99,7 @@ describe("single-line file edits", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}-3:${lineHash("ccc")}`,
+          range: `2-3`,
           content: "merged",
         },
       ],
@@ -118,7 +118,7 @@ describe("single-line file edits", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "",
         },
       ],
@@ -135,7 +135,7 @@ describe("single-line file edits", () => {
 // =============================================================================
 
 describe("empty file operations", () => {
-  test("insert into empty file via +0: prefix", async () => {
+  test("insert into empty file via +0 prefix", async () => {
     const { path } = setupFile("empty.txt", "");
 
     const result = await handleEdit({
@@ -143,7 +143,7 @@ describe("empty file operations", () => {
       edits: [
         {
           checksum: EMPTY_FILE_CHECKSUM,
-          range: "+0:",
+          range: "+0",
           content: "first\nsecond",
         },
       ],
@@ -164,7 +164,7 @@ describe("empty file operations", () => {
       edits: [
         {
           checksum: EMPTY_FILE_CHECKSUM,
-          range: "0:",
+          range: "0",
           content: "nope",
         },
       ],
@@ -183,7 +183,7 @@ describe("empty file operations", () => {
       edits: [
         {
           checksum: EMPTY_FILE_CHECKSUM,
-          range: "+0:",
+          range: "+0",
           content: "prepend",
         },
       ],
@@ -207,7 +207,7 @@ describe("insert-after (+ prefix)", () => {
       edits: [
         {
           checksum: cs,
-          range: `+2:${lineHash("bbb")}`,
+          range: `+2`,
           content: "appended",
         },
       ],
@@ -226,7 +226,7 @@ describe("insert-after (+ prefix)", () => {
       edits: [
         {
           checksum: cs,
-          range: `+1:${lineHash("aaa")}`,
+          range: `+1`,
           content: "inserted",
         },
       ],
@@ -237,7 +237,7 @@ describe("insert-after (+ prefix)", () => {
     expect(readFileSync(path, "utf-8")).toBe("aaa\ninserted\nbbb\n");
   });
 
-  test("+0: prefix prepends before all content", async () => {
+  test("+0 prefix prepends before all content", async () => {
     const { path, cs } = setupFile("prepend.txt", "existing\n");
 
     const result = await handleEdit({
@@ -245,7 +245,7 @@ describe("insert-after (+ prefix)", () => {
       edits: [
         {
           checksum: cs,
-          range: "+0:",
+          range: "+0",
           content: "prepended",
         },
       ],
@@ -265,12 +265,12 @@ describe("insert-after (+ prefix)", () => {
       edits: [
         {
           checksum: cs,
-          range: `+1:${lineHash("aaa")}`,
+          range: `+1`,
           content: "after-1",
         },
         {
           checksum: cs,
-          range: `+3:${lineHash("ccc")}`,
+          range: `+3`,
           content: "after-3",
         },
       ],
@@ -289,12 +289,12 @@ describe("insert-after (+ prefix)", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "BBB",
         },
         {
           checksum: cs,
-          range: `+2:${lineHash("bbb")}`,
+          range: `+2`,
           content: "inserted",
         },
       ],
@@ -319,7 +319,7 @@ describe("multi-line replacements", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("aaa")}-3:${lineHash("ccc")}`,
+          range: `1-3`,
           content: "entirely\nnew",
         },
       ],
@@ -338,12 +338,12 @@ describe("multi-line replacements", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("aaa")}`,
+          range: `1`,
           content: "AAA",
         },
         {
           checksum: cs,
-          range: `3:${lineHash("ccc")}`,
+          range: `3`,
           content: "CCC",
         },
       ],
@@ -362,7 +362,7 @@ describe("multi-line replacements", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("aaa")}-3:${lineHash("ccc")}`,
+          range: `1-3`,
           content: "",
         },
       ],
@@ -389,7 +389,7 @@ describe("no-op detection", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "bbb",
         },
       ],
@@ -409,7 +409,7 @@ describe("no-op detection", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("aaa")}-3:${lineHash("ccc")}`,
+          range: `1-3`,
           content: "aaa\nbbb\nccc",
         },
       ],
@@ -435,7 +435,7 @@ describe("checksum validation", () => {
       edits: [
         {
           checksum: narrowCs,
-          range: `3:${lineHash("ccc")}`,
+          range: `3`,
           content: "CCC",
         },
       ],
@@ -455,7 +455,7 @@ describe("checksum validation", () => {
       edits: [
         {
           checksum: narrowCs,
-          range: `4:${lineHash("ddd")}`,
+          range: `4`,
           content: "DDD",
         },
       ],
@@ -474,12 +474,12 @@ describe("checksum validation", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("aaa")}`,
+          range: `1`,
           content: "AAA",
         },
         {
           checksum: cs,
-          range: `4:${lineHash("ddd")}`,
+          range: `4`,
           content: "DDD",
         },
       ],
@@ -500,7 +500,7 @@ describe("checksum validation", () => {
       edits: [
         {
           checksum: fakeCs,
-          range: `1:${lineHash("aaa")}`,
+          range: `1`,
           content: "AAA",
         },
       ],
@@ -529,7 +529,7 @@ describe("line ending preservation", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "BBB",
         },
       ],
@@ -554,7 +554,7 @@ describe("line ending preservation", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("aaa")}-2:${lineHash("bbb")}`,
+          range: `1-2`,
           content: "XXX\nYYY\nZZZ",
         },
       ],
@@ -578,7 +578,7 @@ describe("line ending preservation", () => {
       edits: [
         {
           checksum: cs,
-          range: `+2:${lineHash("bbb")}`,
+          range: `+2`,
           content: "appended",
         },
       ],
@@ -606,7 +606,7 @@ describe("unicode in edits", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("hello")}`,
+          range: `1`,
           content: "🎉 héllo 𝕳",
         },
       ],
@@ -625,7 +625,7 @@ describe("unicode in edits", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("中文")}`,
+          range: `2`,
           content: "中文（修正済み）",
         },
       ],
@@ -656,18 +656,13 @@ describe("read-then-edit round-trip", () => {
     expect(csMatch).toBeTruthy();
     const cs = csMatch![1];
 
-    // Extract line hash for line 2
-    const lineMatch = text.match(/^2:([a-z]{2})\t/m);
-    expect(lineMatch).toBeTruthy();
-    const lh = lineMatch![1];
-
     // Edit using the extracted values
     const editResult = await handleEdit({
       file_path: f,
       edits: [
         {
           checksum: cs,
-          range: `2:${lh}`,
+          range: `2`,
           content: "BETA",
         },
       ],
@@ -694,15 +689,13 @@ describe("read-then-edit round-trip", () => {
 
     const csMatch = text.match(/checksum: (.+)/);
     const cs = csMatch![1];
-    const lineMatch = text.match(/^3:([a-z]{2})\t/m);
-    const lh = lineMatch![1];
 
     const editResult = await handleEdit({
       file_path: f,
       edits: [
         {
           checksum: cs,
-          range: `3:${lh}`,
+          range: `3`,
           content: "CCC",
         },
       ],
@@ -724,7 +717,7 @@ describe("read-then-edit round-trip", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "BBB",
         },
       ],
@@ -737,8 +730,6 @@ describe("read-then-edit round-trip", () => {
     const text = readResult.content[0].text;
     const csMatch = text.match(/checksum: (.+)/);
     const newCs = csMatch![1];
-    const lineMatch = text.match(/^3:([a-z]{2})\t/m);
-    const lh = lineMatch![1];
 
     // Second edit using new checksum
     const edit2 = await handleEdit({
@@ -746,7 +737,7 @@ describe("read-then-edit round-trip", () => {
       edits: [
         {
           checksum: newCs,
-          range: `3:${lh}`,
+          range: `3`,
           content: "CCC",
         },
       ],
@@ -769,8 +760,8 @@ describe("overlap detection", () => {
     const result = await handleEdit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `2:${lineHash("bbb")}`, content: "X" },
-        { checksum: cs, range: `2:${lineHash("bbb")}`, content: "Y" },
+        { checksum: cs, range: `2`, content: "X" },
+        { checksum: cs, range: `2`, content: "Y" },
       ],
       projectDir: testDir,
     });
@@ -785,8 +776,8 @@ describe("overlap detection", () => {
     const result = await handleEdit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${lineHash("aaa")}-2:${lineHash("bbb")}`, content: "AB" },
-        { checksum: cs, range: `3:${lineHash("ccc")}-4:${lineHash("ddd")}`, content: "CD" },
+        { checksum: cs, range: `1-2`, content: "AB" },
+        { checksum: cs, range: `3-4`, content: "CD" },
       ],
       projectDir: testDir,
     });
@@ -803,12 +794,12 @@ describe("overlap detection", () => {
       edits: [
         {
           checksum: cs,
-          range: `+1:${lineHash("aaa")}`,
+          range: `+1`,
           content: "ins1",
         },
         {
           checksum: cs,
-          range: `+1:${lineHash("aaa")}`,
+          range: `+1`,
           content: "ins2",
         },
       ],
@@ -819,70 +810,6 @@ describe("overlap detection", () => {
     const written = readFileSync(path, "utf-8");
     expect(written).toContain("ins1");
     expect(written).toContain("ins2");
-  });
-});
-
-// =============================================================================
-// Hash verification
-// =============================================================================
-
-describe("hash verification", () => {
-  test("wrong start hash on multi-line range is rejected", async () => {
-    const { path, cs } = setupFile("bad-start.txt", "aaa\nbbb\nccc\n");
-
-    const result = await handleEdit({
-      file_path: path,
-      edits: [
-        {
-          checksum: cs,
-          range: `1:zz-3:${lineHash("ccc")}`,
-
-          content: "new",
-        },
-      ],
-      projectDir: testDir,
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("mismatch");
-  });
-
-  test("wrong end hash on multi-line range is rejected", async () => {
-    const { path, cs } = setupFile("bad-end.txt", "aaa\nbbb\nccc\n");
-
-    const result = await handleEdit({
-      file_path: path,
-      edits: [
-        {
-          checksum: cs,
-          range: `1:${lineHash("aaa")}-3:zz`,
-          content: "new",
-        },
-      ],
-      projectDir: testDir,
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("mismatch");
-  });
-
-  test("correct hashes on multi-line range pass", async () => {
-    const { path, cs } = setupFile("good-hash.txt", "aaa\nbbb\nccc\n");
-
-    const result = await handleEdit({
-      file_path: path,
-      edits: [
-        {
-          checksum: cs,
-          range: `1:${lineHash("aaa")}-3:${lineHash("ccc")}`,
-          content: "only",
-        },
-      ],
-      projectDir: testDir,
-    });
-
-    expect(result.isError).toBeUndefined();
-    expect(readFileSync(path, "utf-8")).toBe("only\n");
   });
 });
 
@@ -902,7 +829,7 @@ describe("stale file detection", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "BBB",
         },
       ],
@@ -928,7 +855,7 @@ describe("special content", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("a|b|c")}`,
+          range: `1`,
           content: "x|y|z",
         },
       ],
@@ -947,7 +874,7 @@ describe("special content", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("key: value")}`,
+          range: `1`,
           content: "key: new_value",
         },
       ],
@@ -966,7 +893,7 @@ describe("special content", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("  indented  ")}`,
+          range: `1`,
           content: "    more indented    ",
         },
       ],
@@ -985,7 +912,7 @@ describe("special content", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "\n\n",
         },
       ],
@@ -1017,7 +944,7 @@ describe("file metadata", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${lineHash("aaa")}`,
+          range: `1`,
           content: "AAA",
         },
       ],

--- a/tests/tools/edit-protocol-edge-cases.test.ts
+++ b/tests/tools/edit-protocol-edge-cases.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { handleEdit } from "../../src/tools/edit.ts";
 import { handleRead } from "../../src/tools/read.ts";
-import { lineHash, rangeChecksum } from "../helpers.ts";
+import { rangeChecksum } from "../helpers.ts";
 import { EMPTY_FILE_CHECKSUM } from "../../src/hash.ts";
 
 // =============================================================================
@@ -41,11 +41,10 @@ function edit(opts: { file_path: string; edits: { checksum: string; range: strin
 describe("range format parsing", () => {
   test("single-line shorthand (no dash)", async () => {
     const { path, cs } = setupFile("single.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "BBB" }],
+      edits: [{ checksum: cs, range: `2`, content: "BBB" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -54,18 +53,17 @@ describe("range format parsing", () => {
 
   test("explicit single-line range (N:hash-N:hash)", async () => {
     const { path, cs } = setupFile("explicit.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}-2:${h2}`, content: "BBB" }],
+      edits: [{ checksum: cs, range: `2-2`, content: "BBB" }],
     });
 
     expect(result.isError).toBeUndefined();
     expect(readFileSync(path, "utf-8")).toBe("aaa\nBBB\nccc\n");
   });
 
-  test("rejects malformed range — missing hash", async () => {
+  test("rejects malformed range — trailing colon", async () => {
     const { path, cs } = setupFile("bad.txt", "aaa\nbbb\n");
 
     await expect(
@@ -82,20 +80,18 @@ describe("range format parsing", () => {
     await expect(
       edit({
         file_path: path,
-        edits: [{ checksum: cs, range: "abc:aa-2:bb", content: "x" }],
+        edits: [{ checksum: cs, range: "abc-2", content: "x" }],
       }),
     ).rejects.toThrow();
   });
 
   test("rejects range where start > end", async () => {
     const { path, cs } = setupFile("rev.txt", "aaa\nbbb\nccc\n");
-    const h1 = lineHash("aaa");
-    const h3 = lineHash("ccc");
 
     await expect(
       edit({
         file_path: path,
-        edits: [{ checksum: cs, range: `3:${h3}-1:${h1}`, content: "x" }],
+        edits: [{ checksum: cs, range: `3-1`, content: "x" }],
       }),
     ).rejects.toThrow();
   });
@@ -103,20 +99,20 @@ describe("range format parsing", () => {
   test("rejects line 0 without + prefix", async () => {
     const { path, cs } = setupFile("zero.txt", "aaa\n");
 
-    await expect(
-      edit({
-        file_path: path,
-        edits: [{ checksum: cs, range: "0:aa-0:aa", content: "x" }],
-      }),
-    ).rejects.toThrow();
+    const result = await edit({
+      file_path: path,
+      edits: [{ checksum: cs, range: "0-0", content: "x" }],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("insert-after");
   });
 
-  test("+0: prefix for prepend requires no hash", async () => {
+  test("+0 prefix for prepend", async () => {
     const { path, cs } = setupFile("prepend.txt", "aaa\nbbb\n");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: "+0:", content: "header" }],
+      edits: [{ checksum: cs, range: "+0", content: "header" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -125,11 +121,10 @@ describe("range format parsing", () => {
 
   test("rejects edit targeting line beyond EOF", async () => {
     const { path, cs } = setupFile("short.txt", "aaa\nbbb\n");
-    const h = lineHash("aaa");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `99:${h}-99:${h}`, content: "x" }],
+      edits: [{ checksum: cs, range: `99-99`, content: "x" }],
     });
 
     expect(result.isError).toBe(true);
@@ -143,11 +138,10 @@ describe("range format parsing", () => {
 describe("insert-after (+) semantics", () => {
   test("insert after the very last line", async () => {
     const { path, cs } = setupFile("append.txt", "aaa\nbbb\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `+2:${h2}`, content: "ccc" }],
+      edits: [{ checksum: cs, range: `+2`, content: "ccc" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -156,13 +150,12 @@ describe("insert-after (+) semantics", () => {
 
   test("multiple inserts at the same anchor preserve order", async () => {
     const { path, cs } = setupFile("multi-ins.txt", "aaa\nbbb\n");
-    const h1 = lineHash("aaa");
 
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `+1:${h1}`, content: "first" },
-        { checksum: cs, range: `+1:${h1}`, content: "second" },
+        { checksum: cs, range: `+1`, content: "first" },
+        { checksum: cs, range: `+1`, content: "second" },
       ],
     });
 
@@ -173,13 +166,12 @@ describe("insert-after (+) semantics", () => {
 
   test("insert-after and replace at the same line", async () => {
     const { path, cs } = setupFile("ins-rep.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `2:${h2}`, content: "BBB" },
-        { checksum: cs, range: `+2:${h2}`, content: "inserted" },
+        { checksum: cs, range: `2`, content: "BBB" },
+        { checksum: cs, range: `+2`, content: "inserted" },
       ],
     });
 
@@ -191,24 +183,23 @@ describe("insert-after (+) semantics", () => {
 
   test("insert multiple lines after an anchor", async () => {
     const { path, cs } = setupFile("multi-line-ins.txt", "aaa\nbbb\n");
-    const h1 = lineHash("aaa");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `+1:${h1}`, content: "x\ny\nz" }],
+      edits: [{ checksum: cs, range: `+1`, content: "x\ny\nz" }],
     });
 
     expect(result.isError).toBeUndefined();
     expect(readFileSync(path, "utf-8")).toBe("aaa\nx\ny\nz\nbbb\n");
   });
 
-  test("insert into empty file via +0:", async () => {
+  test("insert into empty file via +0", async () => {
     const f = join(testDir, "empty.txt");
     writeFileSync(f, "");
 
     const result = await edit({
       file_path: f,
-      edits: [{ checksum: EMPTY_FILE_CHECKSUM, range: "+0:", content: "first line\nsecond line" }],
+      edits: [{ checksum: EMPTY_FILE_CHECKSUM, range: "+0", content: "first line\nsecond line" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -225,14 +216,12 @@ describe("insert-after (+) semantics", () => {
 describe("multi-edit batches", () => {
   test("two non-overlapping replacements in one call", async () => {
     const { path, cs } = setupFile("batch.txt", "aaa\nbbb\nccc\nddd\neee\n");
-    const h1 = lineHash("aaa");
-    const h3 = lineHash("ccc");
 
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${h1}`, content: "AAA" },
-        { checksum: cs, range: `3:${h3}`, content: "CCC" },
+        { checksum: cs, range: `1`, content: "AAA" },
+        { checksum: cs, range: `3`, content: "CCC" },
       ],
     });
 
@@ -242,15 +231,13 @@ describe("multi-edit batches", () => {
 
   test("edits provided out of order succeed (engine sorts)", async () => {
     const { path, cs } = setupFile("unsorted.txt", "aaa\nbbb\nccc\nddd\n");
-    const h3 = lineHash("ccc");
-    const h1 = lineHash("aaa");
 
     // Provide edit for line 3 before edit for line 1
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `3:${h3}`, content: "CCC" },
-        { checksum: cs, range: `1:${h1}`, content: "AAA" },
+        { checksum: cs, range: `3`, content: "CCC" },
+        { checksum: cs, range: `1`, content: "AAA" },
       ],
     });
 
@@ -260,14 +247,12 @@ describe("multi-edit batches", () => {
 
   test("batch with replace + insert-after at different lines", async () => {
     const { path, cs } = setupFile("mixed.txt", "aaa\nbbb\nccc\n");
-    const h1 = lineHash("aaa");
-    const h3 = lineHash("ccc");
 
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${h1}`, content: "AAA" },
-        { checksum: cs, range: `+3:${h3}`, content: "ddd" },
+        { checksum: cs, range: `1`, content: "AAA" },
+        { checksum: cs, range: `+3`, content: "ddd" },
       ],
     });
 
@@ -277,15 +262,12 @@ describe("multi-edit batches", () => {
 
   test("overlapping replace ranges are rejected", async () => {
     const { path, cs } = setupFile("overlap.txt", "aaa\nbbb\nccc\nddd\n");
-    const h1 = lineHash("aaa");
-    const h2 = lineHash("bbb");
-    const h3 = lineHash("ccc");
 
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${h1}-2:${h2}`, content: "X" },
-        { checksum: cs, range: `2:${h2}-3:${h3}`, content: "Y" },
+        { checksum: cs, range: `1-2`, content: "X" },
+        { checksum: cs, range: `2-3`, content: "Y" },
       ],
     });
 
@@ -295,16 +277,12 @@ describe("multi-edit batches", () => {
 
   test("adjacent ranges (non-overlapping) succeed", async () => {
     const { path, cs } = setupFile("adjacent.txt", "aaa\nbbb\nccc\nddd\n");
-    const h1 = lineHash("aaa");
-    const h2 = lineHash("bbb");
-    const h3 = lineHash("ccc");
-    const h4 = lineHash("ddd");
 
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${h1}-2:${h2}`, content: "AA\nBB" },
-        { checksum: cs, range: `3:${h3}-4:${h4}`, content: "CC\nDD" },
+        { checksum: cs, range: `1-2`, content: "AA\nBB" },
+        { checksum: cs, range: `3-4`, content: "CC\nDD" },
       ],
     });
 
@@ -335,11 +313,10 @@ describe("checksum coverage", () => {
   test("narrow checksum covering only the edited line works", async () => {
     const { path, lines } = setupFile("narrow.txt", "aaa\nbbb\nccc\nddd\neee\n");
     const narrowCs = rangeChecksum(lines, 2, 4);
-    const h3 = lineHash("ccc");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: narrowCs, range: `3:${h3}`, content: "CCC" }],
+      edits: [{ checksum: narrowCs, range: `3`, content: "CCC" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -350,11 +327,10 @@ describe("checksum coverage", () => {
     const { path, lines } = setupFile("partial.txt", "aaa\nbbb\nccc\nddd\neee\n");
     // Checksum covers lines 1-3 but edit targets line 5
     const narrowCs = rangeChecksum(lines, 1, 3);
-    const h5 = lineHash("eee");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: narrowCs, range: `5:${h5}`, content: "EEE" }],
+      edits: [{ checksum: narrowCs, range: `5`, content: "EEE" }],
     });
 
     expect(result.isError).toBe(true);
@@ -365,11 +341,10 @@ describe("checksum coverage", () => {
     const { path, lines } = setupFile("partial-ins.txt", "aaa\nbbb\nccc\n");
     // Only cover lines 1-2
     const narrowCs = rangeChecksum(lines, 1, 2);
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: narrowCs, range: `+2:${h2}`, content: "inserted" }],
+      edits: [{ checksum: narrowCs, range: `+2`, content: "inserted" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -381,7 +356,7 @@ describe("checksum coverage", () => {
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: EMPTY_FILE_CHECKSUM, range: "+0:", content: "x" }],
+      edits: [{ checksum: EMPTY_FILE_CHECKSUM, range: "+0", content: "x" }],
     });
 
     expect(result.isError).toBe(true);
@@ -395,11 +370,10 @@ describe("checksum coverage", () => {
 describe("content growth and shrinkage", () => {
   test("replace one line with many (file grows)", async () => {
     const { path, cs } = setupFile("grow.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "x1\nx2\nx3\nx4\nx5" }],
+      edits: [{ checksum: cs, range: `2`, content: "x1\nx2\nx3\nx4\nx5" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -408,12 +382,10 @@ describe("content growth and shrinkage", () => {
 
   test("replace many lines with one (file shrinks)", async () => {
     const { path, cs } = setupFile("shrink.txt", "aaa\nbbb\nccc\nddd\neee\n");
-    const h2 = lineHash("bbb");
-    const h4 = lineHash("ddd");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}-4:${h4}`, content: "only" }],
+      edits: [{ checksum: cs, range: `2-4`, content: "only" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -422,12 +394,10 @@ describe("content growth and shrinkage", () => {
 
   test("delete lines (empty content string)", async () => {
     const { path, cs } = setupFile("delete.txt", "aaa\nbbb\nccc\nddd\n");
-    const h2 = lineHash("bbb");
-    const h3 = lineHash("ccc");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}-3:${h3}`, content: "" }],
+      edits: [{ checksum: cs, range: `2-3`, content: "" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -436,12 +406,10 @@ describe("content growth and shrinkage", () => {
 
   test("delete all lines leaves empty file", async () => {
     const { path, cs } = setupFile("delall.txt", "aaa\nbbb\n");
-    const h1 = lineHash("aaa");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${h1}-2:${h2}`, content: "" }],
+      edits: [{ checksum: cs, range: `1-2`, content: "" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -450,11 +418,10 @@ describe("content growth and shrinkage", () => {
 
   test("replace with empty then chain a second edit using returned checksum", async () => {
     const { path, cs } = setupFile("chain.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const r1 = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "" }],
+      edits: [{ checksum: cs, range: `2`, content: "" }],
     });
     expect(r1.isError).toBeUndefined();
 
@@ -463,10 +430,9 @@ describe("content growth and shrinkage", () => {
     expect(csMatch).not.toBeNull();
     const newCs = csMatch![1];
 
-    const h1 = lineHash("aaa");
     const r2 = await edit({
       file_path: path,
-      edits: [{ checksum: newCs, range: `1:${h1}`, content: "AAA" }],
+      edits: [{ checksum: newCs, range: `1`, content: "AAA" }],
     });
     expect(r2.isError).toBeUndefined();
     expect(readFileSync(path, "utf-8")).toBe("AAA\nccc\n");
@@ -480,11 +446,10 @@ describe("content growth and shrinkage", () => {
 describe("unicode and special content", () => {
   test("emoji content hashes and edits correctly", async () => {
     const { path, cs } = setupFile("emoji.txt", "hello\n🎉🎊🎈\nworld\n");
-    const h2 = lineHash("🎉🎊🎈");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "🚀 launched" }],
+      edits: [{ checksum: cs, range: `2`, content: "🚀 launched" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -493,11 +458,10 @@ describe("unicode and special content", () => {
 
   test("CJK characters", async () => {
     const { path, cs } = setupFile("cjk.txt", "你好\n世界\n测试\n");
-    const h2 = lineHash("世界");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "地球" }],
+      edits: [{ checksum: cs, range: `2`, content: "地球" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -508,11 +472,10 @@ describe("unicode and special content", () => {
     // These chars appear in the trueline format itself — ensure they
     // don't confuse the parser when they're in file content.
     const { path, cs } = setupFile("special.txt", "key:value|extra\nnormal\n");
-    const h1 = lineHash("key:value|extra");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${h1}`, content: "new:val|stuff" }],
+      edits: [{ checksum: cs, range: `1`, content: "new:val|stuff" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -521,14 +484,12 @@ describe("unicode and special content", () => {
 
   test("lines with only whitespace", async () => {
     const { path, cs } = setupFile("ws.txt", "  \n\t\t\n   \n");
-    const h1 = lineHash("  ");
-    const h2 = lineHash("\t\t");
 
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${h1}`, content: "trimmed" },
-        { checksum: cs, range: `2:${h2}`, content: "also trimmed" },
+        { checksum: cs, range: `1`, content: "trimmed" },
+        { checksum: cs, range: `2`, content: "also trimmed" },
       ],
     });
 
@@ -538,11 +499,10 @@ describe("unicode and special content", () => {
 
   test("single newline in content string produces empty line", async () => {
     const { path, cs } = setupFile("blank.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "\n" }],
+      edits: [{ checksum: cs, range: `2`, content: "\n" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -552,11 +512,10 @@ describe("unicode and special content", () => {
   test("very long line", async () => {
     const longLine = "x".repeat(10000);
     const { path, cs } = setupFile("long.txt", `aaa\n${longLine}\nccc\n`);
-    const h2 = lineHash(longLine);
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "short" }],
+      edits: [{ checksum: cs, range: `2`, content: "short" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -571,11 +530,10 @@ describe("unicode and special content", () => {
 describe("line ending edge cases", () => {
   test("CRLF file: replacement uses CRLF", async () => {
     const { path, cs } = setupFile("crlf.txt", "aaa\r\nbbb\r\nccc\r\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "BBB" }],
+      edits: [{ checksum: cs, range: `2`, content: "BBB" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -585,11 +543,10 @@ describe("line ending edge cases", () => {
 
   test("LF file: no CRLF introduced by edit", async () => {
     const { path, cs } = setupFile("lf.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "BBB" }],
+      edits: [{ checksum: cs, range: `2`, content: "BBB" }],
     });
 
     const written = readFileSync(path, "utf-8");
@@ -598,11 +555,10 @@ describe("line ending edge cases", () => {
 
   test("file without trailing newline preserves that after edit", async () => {
     const { path, cs } = setupFile("notl.txt", "aaa\nbbb");
-    const h1 = lineHash("aaa");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${h1}`, content: "AAA" }],
+      edits: [{ checksum: cs, range: `1`, content: "AAA" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -613,11 +569,10 @@ describe("line ending edge cases", () => {
 
   test("file with trailing newline preserves it after edit", async () => {
     const { path, cs } = setupFile("tl.txt", "aaa\nbbb\n");
-    const h1 = lineHash("aaa");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${h1}`, content: "AAA" }],
+      edits: [{ checksum: cs, range: `1`, content: "AAA" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -634,11 +589,10 @@ describe("line ending edge cases", () => {
 describe("no-op detection", () => {
   test("replacing line with identical content is a no-op", async () => {
     const { path, cs } = setupFile("noop1.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "bbb" }],
+      edits: [{ checksum: cs, range: `2`, content: "bbb" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -647,12 +601,10 @@ describe("no-op detection", () => {
 
   test("replacing multi-line range with identical content is a no-op", async () => {
     const { path, cs } = setupFile("noop2.txt", "aaa\nbbb\nccc\n");
-    const h1 = lineHash("aaa");
-    const h3 = lineHash("ccc");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${h1}-3:${h3}`, content: "aaa\nbbb\nccc" }],
+      edits: [{ checksum: cs, range: `1-3`, content: "aaa\nbbb\nccc" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -661,11 +613,10 @@ describe("no-op detection", () => {
 
   test("insert-after with content is not a no-op (always changes file)", async () => {
     const { path, cs } = setupFile("ins-noop.txt", "aaa\nbbb\n");
-    const h1 = lineHash("aaa");
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `+1:${h1}`, content: "inserted" }],
+      edits: [{ checksum: cs, range: `+1`, content: "inserted" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -680,11 +631,10 @@ describe("no-op detection", () => {
 describe("returned checksum enables chaining", () => {
   test("returned checksum works for a subsequent edit", async () => {
     const { path, cs } = setupFile("chain1.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     const r1 = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "BBB" }],
+      edits: [{ checksum: cs, range: `2`, content: "BBB" }],
     });
     expect(r1.isError).toBeUndefined();
 
@@ -692,10 +642,9 @@ describe("returned checksum enables chaining", () => {
     expect(csMatch).not.toBeNull();
     const newCs = csMatch![1];
 
-    const hBBB = lineHash("BBB");
     const r2 = await edit({
       file_path: path,
-      edits: [{ checksum: newCs, range: `2:${hBBB}`, content: "FINAL" }],
+      edits: [{ checksum: newCs, range: `2`, content: "FINAL" }],
     });
 
     expect(r2.isError).toBeUndefined();
@@ -704,18 +653,16 @@ describe("returned checksum enables chaining", () => {
 
   test("old checksum is rejected after file was edited", async () => {
     const { path, cs } = setupFile("stale.txt", "aaa\nbbb\nccc\n");
-    const h2 = lineHash("bbb");
 
     await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}`, content: "BBB" }],
+      edits: [{ checksum: cs, range: `2`, content: "BBB" }],
     });
 
     // Try using the old checksum — file has changed
-    const h3 = lineHash("ccc");
     const r2 = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `3:${h3}`, content: "CCC" }],
+      edits: [{ checksum: cs, range: `3`, content: "CCC" }],
     });
 
     expect(r2.isError).toBe(true);
@@ -742,10 +689,9 @@ describe("read-then-edit round-trip", () => {
     const csMatch = readResult.content[0].text.match(/checksum:\s*(\d+-\d+:[0-9a-f]+)/);
     expect(csMatch).not.toBeNull();
 
-    const hBeta = lineHash("beta");
     const editResult = await edit({
       file_path: f,
-      edits: [{ checksum: csMatch![1], range: `2:${hBeta}`, content: "BETA" }],
+      edits: [{ checksum: csMatch![1], range: `2`, content: "BETA" }],
     });
 
     expect(editResult.isError).toBeUndefined();
@@ -767,10 +713,9 @@ describe("read-then-edit round-trip", () => {
     const csMatch = readResult.content[0].text.match(/checksum:\s*(\d+-\d+:[0-9a-f]+)/);
     expect(csMatch).not.toBeNull();
 
-    const hCcc = lineHash("ccc");
     const editResult = await edit({
       file_path: f,
-      edits: [{ checksum: csMatch![1], range: `3:${hCcc}`, content: "CCC" }],
+      edits: [{ checksum: csMatch![1], range: `3`, content: "CCC" }],
     });
 
     expect(editResult.isError).toBeUndefined();
@@ -795,7 +740,7 @@ describe("stale checksum recovery hints", () => {
 
     const result = await edit({
       file_path: f,
-      edits: [{ checksum: cs, range: `2:${lineHash("bbb")}`, content: "BBB" }],
+      edits: [{ checksum: cs, range: `2`, content: "BBB" }],
     });
 
     expect(result.isError).toBe(true);
@@ -803,7 +748,7 @@ describe("stale checksum recovery hints", () => {
     expect(text).toContain("ranges=");
   });
 
-  test("no narrow re-read hint when edit-target line itself changed", async () => {
+  test("stale checksum when edit-target line itself changed", async () => {
     const f = join(testDir, "stale-target.txt");
     writeFileSync(f, "aaa\nbbb\nccc\n");
 
@@ -815,56 +760,12 @@ describe("stale checksum recovery hints", () => {
 
     const result = await edit({
       file_path: f,
-      edits: [{ checksum: cs, range: `2:${lineHash("bbb")}`, content: "xxx" }],
+      edits: [{ checksum: cs, range: `2`, content: "xxx" }],
     });
 
     expect(result.isError).toBe(true);
     const text = result.content[0].text;
-    expect(text).not.toContain("ranges=");
-  });
-});
-
-// =============================================================================
-// Hash verification
-// =============================================================================
-
-describe("boundary hash verification", () => {
-  test("wrong start hash rejected", async () => {
-    const { path, cs } = setupFile("bad-start.txt", "aaa\nbbb\nccc\n");
-
-    const result = await edit({
-      file_path: path,
-      edits: [{ checksum: cs, range: `1:zz-2:${lineHash("bbb")}`, content: "x\ny" }],
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("mismatch");
-  });
-
-  test("wrong end hash rejected", async () => {
-    const { path, cs } = setupFile("bad-end.txt", "aaa\nbbb\nccc\n");
-
-    const result = await edit({
-      file_path: path,
-      edits: [{ checksum: cs, range: lineHash("aaa") ? `1:${lineHash("aaa")}-2:zz` : "1:aa-2:zz", content: "x\ny" }],
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("mismatch");
-  });
-
-  test("correct hashes on multi-line range pass", async () => {
-    const { path, cs } = setupFile("good-hash.txt", "aaa\nbbb\nccc\nddd\n");
-    const h1 = lineHash("aaa");
-    const h4 = lineHash("ddd");
-
-    const result = await edit({
-      file_path: path,
-      edits: [{ checksum: cs, range: `1:${h1}-4:${h4}`, content: "only one line" }],
-    });
-
-    expect(result.isError).toBeUndefined();
-    expect(readFileSync(path, "utf-8")).toBe("only one line\n");
+    expect(text).toContain("mismatch");
   });
 });
 
@@ -881,7 +782,7 @@ describe("security and file validation", () => {
     try {
       const result = await edit({
         file_path: outsideFile,
-        edits: [{ checksum: "1-1:00000000", range: "1:aa", content: "hacked" }],
+        edits: [{ checksum: "1-1:00000000", range: "1", content: "hacked" }],
       });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("outside");
@@ -896,7 +797,7 @@ describe("security and file validation", () => {
 
     const result = await edit({
       file_path: binFile,
-      edits: [{ checksum: "1-1:00000000", range: "1:aa", content: "text" }],
+      edits: [{ checksum: "1-1:00000000", range: "1", content: "text" }],
     });
 
     expect(result.isError).toBe(true);
@@ -906,7 +807,7 @@ describe("security and file validation", () => {
   test("rejects directory path", async () => {
     const result = await edit({
       file_path: testDir,
-      edits: [{ checksum: "1-1:00000000", range: "1:aa", content: "x" }],
+      edits: [{ checksum: "1-1:00000000", range: "1", content: "x" }],
     });
 
     expect(result.isError).toBe(true);
@@ -915,7 +816,7 @@ describe("security and file validation", () => {
   test("rejects nonexistent file", async () => {
     const result = await edit({
       file_path: join(testDir, "does-not-exist.txt"),
-      edits: [{ checksum: "1-1:00000000", range: "1:aa", content: "x" }],
+      edits: [{ checksum: "1-1:00000000", range: "1", content: "x" }],
     });
 
     expect(result.isError).toBe(true);
@@ -929,11 +830,10 @@ describe("security and file validation", () => {
 
     const lines = ["aaa", "bbb"];
     const cs = rangeChecksum(lines, 1, 2);
-    const h1 = lineHash("aaa");
 
     const result = await edit({
       file_path: linkFile,
-      edits: [{ checksum: cs, range: `1:${h1}`, content: "AAA" }],
+      edits: [{ checksum: cs, range: `1`, content: "AAA" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -950,7 +850,7 @@ describe("security and file validation", () => {
     try {
       const result = await edit({
         file_path: linkFile,
-        edits: [{ checksum: "1-1:00000000", range: "1:aa", content: "hacked" }],
+        edits: [{ checksum: "1-1:00000000", range: "1", content: "hacked" }],
       });
       expect(result.isError).toBe(true);
     } finally {
@@ -972,11 +872,10 @@ describe("security and file validation", () => {
 
     const lines = ["hunter2"];
     const cs = rangeChecksum(lines, 1, 1);
-    const h = lineHash("hunter2");
 
     const result = await edit({
       file_path: secretFile,
-      edits: [{ checksum: cs, range: `1:${h}`, content: "redacted" }],
+      edits: [{ checksum: cs, range: `1`, content: "redacted" }],
     });
 
     expect(result.isError).toBe(true);
@@ -997,13 +896,11 @@ describe("large file edits", () => {
     const content = `${lines.join("\n")}\n`;
     const { path } = setupFile("large.txt", content);
 
-    const target = "line 500";
-    const h500 = lineHash(target);
     const narrowCs = rangeChecksum(lines, 498, 502);
 
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: narrowCs, range: `500:${h500}`, content: "REPLACED 500" }],
+      edits: [{ checksum: narrowCs, range: `500`, content: "REPLACED 500" }],
     });
 
     expect(result.isError).toBeUndefined();
@@ -1024,9 +921,9 @@ describe("large file edits", () => {
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${lineHash("line 1")}`, content: "FIRST" },
-        { checksum: cs, range: `250:${lineHash("line 250")}`, content: "MIDDLE" },
-        { checksum: cs, range: `500:${lineHash("line 500")}`, content: "LAST" },
+        { checksum: cs, range: `1`, content: "FIRST" },
+        { checksum: cs, range: `250`, content: "MIDDLE" },
+        { checksum: cs, range: `500`, content: "LAST" },
       ],
     });
 
@@ -1045,25 +942,23 @@ describe("large file edits", () => {
 describe("checksum format validation", () => {
   test("rejects checksum without range prefix", async () => {
     const { path } = setupFile("nopfx.txt", "aaa\n");
-    const h = lineHash("aaa");
 
     // Just the hex part, no "1-1:" prefix
     await expect(
       edit({
         file_path: path,
-        edits: [{ checksum: "abcdef01", range: `1:${h}`, content: "x" }],
+        edits: [{ checksum: "abcdef01", range: `1`, content: "x" }],
       }),
     ).rejects.toThrow();
   });
 
   test("rejects completely garbled checksum", async () => {
     const { path } = setupFile("garbled.txt", "aaa\n");
-    const h = lineHash("aaa");
 
     await expect(
       edit({
         file_path: path,
-        edits: [{ checksum: "not-a-checksum", range: `1:${h}`, content: "x" }],
+        edits: [{ checksum: "not-a-checksum", range: `1`, content: "x" }],
       }),
     ).rejects.toThrow();
   });

--- a/tests/tools/edit-summary.test.ts
+++ b/tests/tools/edit-summary.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, realpathSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { handleEdit } from "../../src/tools/edit.ts";
-import { lineHash, rangeChecksum } from "../helpers.ts";
+import { rangeChecksum } from "../helpers.ts";
 import { EMPTY_FILE_CHECKSUM } from "../../src/hash.ts";
 
 let testDir: string;
@@ -38,7 +38,7 @@ describe("edit summary", () => {
     const { path, cs } = setupFile("a.txt", "aaa\nbbb\nccc\n");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${lineHash("bbb")}`, content: "xxx\nyyy\nzzz" }],
+      edits: [{ checksum: cs, range: `2`, content: "xxx\nyyy\nzzz" }],
     });
 
     const text = result.content[0].text;
@@ -47,11 +47,9 @@ describe("edit summary", () => {
 
   test("multi-line replace shows range and delta", async () => {
     const { path, cs } = setupFile("b.txt", "aaa\nbbb\nccc\nddd\neee\n");
-    const h2 = lineHash("bbb");
-    const h4 = lineHash("ddd");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${h2}-4:${h4}`, content: "xxx" }],
+      edits: [{ checksum: cs, range: `2-4`, content: "xxx" }],
     });
 
     const text = result.content[0].text;
@@ -62,7 +60,7 @@ describe("edit summary", () => {
     const { path, cs } = setupFile("c.txt", "aaa\nbbb\n");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${lineHash("aaa")}`, content: "xxx" }],
+      edits: [{ checksum: cs, range: `1`, content: "xxx" }],
     });
 
     const text = result.content[0].text;
@@ -71,11 +69,9 @@ describe("edit summary", () => {
 
   test("deletion shows deleted with line count", async () => {
     const { path, cs } = setupFile("d.txt", "aaa\nbbb\nccc\n");
-    const h1 = lineHash("aaa");
-    const h2 = lineHash("bbb");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${h1}-2:${h2}`, content: "" }],
+      edits: [{ checksum: cs, range: `1-2`, content: "" }],
     });
 
     const text = result.content[0].text;
@@ -86,7 +82,7 @@ describe("edit summary", () => {
     const { path, cs } = setupFile("e.txt", "aaa\nbbb\nccc\n");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `2:${lineHash("bbb")}`, content: "" }],
+      edits: [{ checksum: cs, range: `2`, content: "" }],
     });
 
     const text = result.content[0].text;
@@ -97,7 +93,7 @@ describe("edit summary", () => {
     const { path, cs } = setupFile("f.txt", "aaa\nbbb\n");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `+1:${lineHash("aaa")}`, content: "xxx\nyyy\nzzz" }],
+      edits: [{ checksum: cs, range: `+1`, content: "xxx\nyyy\nzzz" }],
     });
 
     const text = result.content[0].text;
@@ -108,7 +104,7 @@ describe("edit summary", () => {
     const { path, cs } = setupFile("g.txt", "aaa\n");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: "+0:", content: "xxx\nyyy" }],
+      edits: [{ checksum: cs, range: "+0", content: "xxx\nyyy" }],
     });
 
     const text = result.content[0].text;
@@ -119,7 +115,7 @@ describe("edit summary", () => {
     const { path, cs } = setupFile("h.txt", "aaa\nbbb\n");
     const result = await edit({
       file_path: path,
-      edits: [{ checksum: cs, range: `1:${lineHash("aaa")}`, content: "aaa" }],
+      edits: [{ checksum: cs, range: `1`, content: "aaa" }],
     });
 
     const text = result.content[0].text;
@@ -129,13 +125,11 @@ describe("edit summary", () => {
 
   test("batch edit shows one summary line per op", async () => {
     const { path, cs } = setupFile("i.txt", "aaa\nbbb\nccc\nddd\neee\n");
-    const h1 = lineHash("aaa");
-    const h3 = lineHash("ccc");
     const result = await edit({
       file_path: path,
       edits: [
-        { checksum: cs, range: `1:${h1}`, content: "xxx" },
-        { checksum: cs, range: `+3:${h3}`, content: "yyy" },
+        { checksum: cs, range: `1`, content: "xxx" },
+        { checksum: cs, range: `+3`, content: "yyy" },
       ],
     });
 

--- a/tests/tools/edit.test.ts
+++ b/tests/tools/edit.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, realpathSync, writeFileSync, readFileSync, mkdirSync, rmSy
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { handleEdit } from "../../src/tools/edit.ts";
-import { lineHash, rangeChecksum, rawLineHash, rawRangeChecksum } from "../helpers.ts";
+import { rangeChecksum, rawRangeChecksum } from "../helpers.ts";
 
 let testDir: string;
 let testFile: string;
@@ -23,15 +23,13 @@ describe("handleEdit", () => {
   test("replaces a range of lines", async () => {
     const lines = ["line 1", "line 2", "line 3", "line 4"];
     const cs = rangeChecksum(lines, 1, 4);
-    const h2 = lineHash("line 2");
-    const h3 = lineHash("line 3");
 
     const result = await handleEdit({
       file_path: testFile,
       edits: [
         {
           checksum: cs,
-          range: `2:${h2}-3:${h3}`,
+          range: `2-3`,
           content: "replaced 2\nreplaced 3",
         },
       ],
@@ -46,14 +44,13 @@ describe("handleEdit", () => {
   test("inserts after a line", async () => {
     const lines = ["line 1", "line 2", "line 3", "line 4"];
     const cs = rangeChecksum(lines, 1, 4);
-    const h1 = lineHash("line 1");
 
     const result = await handleEdit({
       file_path: testFile,
       edits: [
         {
           checksum: cs,
-          range: `+1:${h1}`,
+          range: `+1`,
           content: "inserted",
         },
       ],
@@ -71,27 +68,7 @@ describe("handleEdit", () => {
       edits: [
         {
           checksum: "1-4:00000000",
-          range: "1:aa-1:aa",
-          content: "nope",
-        },
-      ],
-      projectDir: testDir,
-    });
-
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("mismatch");
-  });
-
-  test("rejects wrong line hash", async () => {
-    const lines = ["line 1", "line 2", "line 3", "line 4"];
-    const cs = rangeChecksum(lines, 1, 4);
-
-    const result = await handleEdit({
-      file_path: testFile,
-      edits: [
-        {
-          checksum: cs,
-          range: "1:zz-1:zz",
+          range: "1-1",
           content: "nope",
         },
       ],
@@ -108,11 +85,10 @@ describe("handleEdit", () => {
 
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h2 = lineHash("line 2");
 
     const result = await handleEdit({
       file_path: crlfFile,
-      edits: [{ checksum: cs, range: `2:${h2}-2:${h2}`, content: "replaced" }],
+      edits: [{ checksum: cs, range: `2-2`, content: "replaced" }],
       projectDir: testDir,
     });
     expect(result.isError).toBeUndefined();
@@ -129,11 +105,10 @@ describe("handleEdit", () => {
 
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h2 = lineHash("line 2");
 
     const result = await handleEdit({
       file_path: mixedFile,
-      edits: [{ checksum: cs, range: `2:${h2}-2:${h2}`, content: "replaced" }],
+      edits: [{ checksum: cs, range: `2-2`, content: "replaced" }],
       projectDir: testDir,
     });
     expect(result.isError).toBeUndefined();
@@ -149,11 +124,10 @@ describe("handleEdit", () => {
 
     const lines = ["line 1", "line 2", "line 3"];
     const cs = rangeChecksum(lines, 1, 3);
-    const h2 = lineHash("line 2");
 
     const result = await handleEdit({
       file_path: mixedFile,
-      edits: [{ checksum: cs, range: `2:${h2}-2:${h2}`, content: "replaced" }],
+      edits: [{ checksum: cs, range: `2-2`, content: "replaced" }],
       projectDir: testDir,
     });
     expect(result.isError).toBeUndefined();
@@ -165,11 +139,10 @@ describe("handleEdit", () => {
   test("preserves LF line endings after edit (no CRLF introduced)", async () => {
     const lines = ["line 1", "line 2", "line 3", "line 4"];
     const cs = rangeChecksum(lines, 1, 4);
-    const h2 = lineHash("line 2");
 
     await handleEdit({
       file_path: testFile,
-      edits: [{ checksum: cs, range: `2:${h2}-2:${h2}`, content: "replaced" }],
+      edits: [{ checksum: cs, range: `2-2`, content: "replaced" }],
       projectDir: testDir,
     });
     const written = readFileSync(testFile, "utf-8");
@@ -179,7 +152,7 @@ describe("handleEdit", () => {
   test("rejects directory path", async () => {
     const result = await handleEdit({
       file_path: testDir,
-      edits: [{ checksum: "1-1:00000000", range: "1:aa-1:aa", content: "x" }],
+      edits: [{ checksum: "1-1:00000000", range: "1-1", content: "x" }],
       projectDir: testDir,
     });
     expect(result.isError).toBe(true);
@@ -191,7 +164,7 @@ describe("handleEdit", () => {
     writeFileSync(binFile, Buffer.from([0x00, 0x01, 0x02, 0x03]));
     const result = await handleEdit({
       file_path: binFile,
-      edits: [{ checksum: "1-1:00000000", range: "1:aa-1:aa", content: "x" }],
+      edits: [{ checksum: "1-1:00000000", range: "1-1", content: "x" }],
       projectDir: testDir,
     });
     expect(result.isError).toBe(true);
@@ -201,7 +174,7 @@ describe("handleEdit", () => {
   test("rejects nonexistent projectDir", async () => {
     const result = await handleEdit({
       file_path: testFile,
-      edits: [{ checksum: "1-1:0000", range: "1:aa-1:aa", content: "x" }],
+      edits: [{ checksum: "1-1:0000", range: "1-1", content: "x" }],
       projectDir: "/nonexistent/does/not/exist",
     });
     expect(result.isError).toBe(true);
@@ -212,14 +185,12 @@ describe("handleEdit", () => {
   test("rejects overlapping ranges", async () => {
     const lines = ["line 1", "line 2", "line 3", "line 4"];
     const cs = rangeChecksum(lines, 1, 4);
-    const h1 = lineHash("line 1");
-    const h2 = lineHash("line 2");
 
     const result = await handleEdit({
       file_path: testFile,
       edits: [
-        { checksum: cs, range: `1:${h1}-2:${h2}`, content: "A" },
-        { checksum: cs, range: `2:${h2}-2:${h2}`, content: "B" },
+        { checksum: cs, range: `1-2`, content: "A" },
+        { checksum: cs, range: `2-2`, content: "B" },
       ],
       projectDir: testDir,
     });
@@ -230,14 +201,13 @@ describe("handleEdit", () => {
   test("rejects checksum that does not cover edit range", async () => {
     const lines = ["line 1", "line 2", "line 3", "line 4"];
     const partialCs = rangeChecksum(lines, 1, 2);
-    const h4 = lineHash("line 4");
 
     const result = await handleEdit({
       file_path: testFile,
       edits: [
         {
           checksum: partialCs,
-          range: `4:${h4}-4:${h4}`,
+          range: `4-4`,
           content: "replaced",
         },
       ],
@@ -254,11 +224,10 @@ describe("handleEdit", () => {
 
     const lines = ["line 1", "line 2"];
     const cs = rangeChecksum(lines, 1, 2);
-    const h1 = lineHash("line 1");
 
     const result = await handleEdit({
       file_path: noTrailingFile,
-      edits: [{ checksum: cs, range: `1:${h1}-1:${h1}`, content: "replaced" }],
+      edits: [{ checksum: cs, range: `1-1`, content: "replaced" }],
       projectDir: testDir,
     });
     expect(result.isError).toBeUndefined();
@@ -275,7 +244,7 @@ describe("handleEdit", () => {
       edits: [
         {
           checksum: "0-0:00000000",
-          range: "+0:",
+          range: "+0",
           content: "new content",
         },
       ],
@@ -300,7 +269,7 @@ describe("handleEdit", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "bbb", // same content
         },
       ],
@@ -329,7 +298,7 @@ describe("handleEdit", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "BBB",
         },
       ],
@@ -342,7 +311,7 @@ describe("handleEdit", () => {
     expect(text).toContain("end:");
   });
 
-  test("checksum failure with changed edit-target lines gives standard error", async () => {
+  test("checksum failure with changed edit-target lines reports mismatch", async () => {
     const filePath = join(testDir, "stale-target.txt");
     writeFileSync(filePath, "aaa\nbbb\nccc\n");
 
@@ -357,7 +326,7 @@ describe("handleEdit", () => {
       edits: [
         {
           checksum: cs,
-          range: `2:${lineHash("bbb")}`,
+          range: `2`,
           content: "xxx",
         },
       ],
@@ -366,8 +335,7 @@ describe("handleEdit", () => {
 
     expect(result.isError).toBe(true);
     const text = result.content[0].text;
-    // Should NOT suggest narrow re-read since target lines changed too
-    expect(text).not.toContain("ranges=");
+    expect(text).toContain("mismatch");
   });
 
   test("denies editing .env file", async () => {
@@ -384,11 +352,10 @@ describe("handleEdit", () => {
 
     const lines = ["SECRET=x"];
     const cs = rangeChecksum(lines, 1, 1);
-    const h = lineHash("SECRET=x");
 
     const result = await handleEdit({
       file_path: envFile,
-      edits: [{ checksum: cs, range: `1:${h}-1:${h}`, content: "hacked" }],
+      edits: [{ checksum: cs, range: `1-1`, content: "hacked" }],
       projectDir: testDir,
     });
 
@@ -405,7 +372,6 @@ describe("handleEdit", () => {
     writeFileSync(latin1File, fileBytes);
 
     const cs = rawRangeChecksum([line1, line2], 1, 2);
-    const h1 = rawLineHash(line1);
 
     const result = await handleEdit({
       file_path: latin1File,
@@ -413,7 +379,7 @@ describe("handleEdit", () => {
       edits: [
         {
           checksum: cs,
-          range: `1:${h1}-1:${h1}`,
+          range: `1-1`,
           content: "résumé",
         },
       ],
@@ -432,12 +398,11 @@ describe("handleEdit", () => {
       writeFileSync(testFile, "line 1\nline 2\nline 3\n");
       const lines = ["line 1", "line 2", "line 3"];
       const cs = rangeChecksum(lines, 1, 3);
-      const h2 = lineHash("line 2");
 
       const result = await handleEdit({
         file_path: testFile,
         dry_run: true,
-        edits: [{ checksum: cs, range: `2:${h2}-2:${h2}`, content: "CHANGED" }],
+        edits: [{ checksum: cs, range: `2-2`, content: "CHANGED" }],
         projectDir: testDir,
       });
 
@@ -456,12 +421,11 @@ describe("handleEdit", () => {
       writeFileSync(testFile, "line 1\nline 2\nline 3\n");
       const lines = ["line 1", "line 2", "line 3"];
       const cs = rangeChecksum(lines, 1, 3);
-      const h2 = lineHash("line 2");
 
       const result = await handleEdit({
         file_path: testFile,
         dry_run: true,
-        edits: [{ checksum: cs, range: `2:${h2}-2:${h2}`, content: "line 2" }],
+        edits: [{ checksum: cs, range: `2-2`, content: "line 2" }],
         projectDir: testDir,
       });
 
@@ -472,7 +436,7 @@ describe("handleEdit", () => {
       const result = await handleEdit({
         file_path: testFile,
         dry_run: true,
-        edits: [{ checksum: "1-3:00000000", range: "1:zz-1:zz", content: "nope" }],
+        edits: [{ checksum: "1-3:00000000", range: "1-1", content: "nope" }],
         projectDir: testDir,
       });
 

--- a/tests/tools/read-edge-cases.test.ts
+++ b/tests/tools/read-edge-cases.test.ts
@@ -38,9 +38,9 @@ describe("empty and minimal files", () => {
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
     const text = result.content[0].text;
-    const lines = text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(/^1:[a-z]{2}\thello$/);
+    expect(lines[0]).toMatch(/^1\thello$/);
   });
 
   test("single line without trailing newline", async () => {
@@ -50,9 +50,9 @@ describe("empty and minimal files", () => {
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
     const text = result.content[0].text;
-    const lines = text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(/^1:[a-z]{2}\thello$/);
+    expect(lines[0]).toMatch(/^1\thello$/);
   });
 
   test("file with only a newline is one empty-string line", async () => {
@@ -62,10 +62,10 @@ describe("empty and minimal files", () => {
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
     const text = result.content[0].text;
-    const lines = text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(1);
     // The line content is empty — so it should be "1:XX|" with nothing after the pipe
-    expect(lines[0]).toMatch(/^1:[a-z]{2}\t$/);
+    expect(lines[0]).toMatch(/^1\t$/);
   });
 
   test("file with multiple blank lines", async () => {
@@ -75,7 +75,7 @@ describe("empty and minimal files", () => {
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
     const text = result.content[0].text;
-    const lines = text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(3);
   });
 });
@@ -92,11 +92,11 @@ describe("line endings", () => {
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
     const text = result.content[0].text;
-    const lines = text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(3);
-    expect(lines[0]).toMatch(/^1:[a-z]{2}\taaa$/);
-    expect(lines[1]).toMatch(/^2:[a-z]{2}\tbbb$/);
-    expect(lines[2]).toMatch(/^3:[a-z]{2}\tccc$/);
+    expect(lines[0]).toMatch(/^1\taaa$/);
+    expect(lines[1]).toMatch(/^2\tbbb$/);
+    expect(lines[2]).toMatch(/^3\tccc$/);
   });
 
   test("CRLF line endings", async () => {
@@ -105,7 +105,7 @@ describe("line endings", () => {
 
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(3);
     // Content should not contain \r
     for (const l of lines) {
@@ -120,7 +120,7 @@ describe("line endings", () => {
 
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(4);
   });
 
@@ -130,9 +130,9 @@ describe("line endings", () => {
 
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(/^1:[a-z]{2}\taaa$/);
+    expect(lines[0]).toMatch(/^1\taaa$/);
   });
 });
 
@@ -147,7 +147,7 @@ describe("unicode content", () => {
 
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(3);
     expect(lines[0]).toContain("日本語");
     expect(lines[1]).toContain("ΣΩΔ");
@@ -160,7 +160,7 @@ describe("unicode content", () => {
 
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain("𝕳ello 🎉");
     expect(lines[1]).toContain("world 𝄞");
@@ -172,7 +172,7 @@ describe("unicode content", () => {
 
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain("  \t  ");
   });
@@ -270,7 +270,7 @@ describe("range parameters", () => {
 
     const result = await handleRead({ file_path: f, ranges: ["1-999"], projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(2);
   });
 
@@ -280,9 +280,9 @@ describe("range parameters", () => {
 
     const result = await handleRead({ file_path: f, ranges: ["2"], projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const lines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toMatch(/^2:[a-z]{2}\tbbb$/);
+    expect(lines[0]).toMatch(/^2\tbbb$/);
   });
 
   test("reading a middle range produces correct checksum", async () => {
@@ -340,16 +340,16 @@ describe("checksum consistency", () => {
     expect(cs1).not.toBe(cs2);
   });
 
-  test("line hash is deterministic across reads", async () => {
+  test("checksum is deterministic across reads", async () => {
     const f = join(testDir, "deterministic.txt");
     writeFileSync(f, "hello world\n");
 
     const r1 = await handleRead({ file_path: f, projectDir: testDir });
     const r2 = await handleRead({ file_path: f, projectDir: testDir });
-    // Extract the hash portion of the first content line
-    const hash1 = r1.content[0].text.split("\n")[0].match(/^1:([a-z]{2})/)?.[1];
-    const hash2 = r2.content[0].text.split("\n")[0].match(/^1:([a-z]{2})/)?.[1];
-    expect(hash1).toBe(hash2);
+    // Extract the checksum line
+    const cs1 = r1.content[0].text.split("\n").find((l) => l.startsWith("checksum:"));
+    const cs2 = r2.content[0].text.split("\n").find((l) => l.startsWith("checksum:"));
+    expect(cs1).toBe(cs2);
   });
 });
 
@@ -375,11 +375,11 @@ describe("long lines", () => {
 
     const result = await handleRead({ file_path: f, projectDir: testDir });
     expect(result.isError).toBeUndefined();
-    const contentLines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+:/));
+    const contentLines = result.content[0].text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(contentLines).toHaveLength(1000);
     // Verify line numbering at boundaries
-    expect(contentLines[0]).toMatch(/^1:/);
-    expect(contentLines[999]).toMatch(/^1000:/);
+    expect(contentLines[0]).toMatch(/^1\t/);
+    expect(contentLines[999]).toMatch(/^1000\t/);
   });
 });
 

--- a/tests/tools/read.test.ts
+++ b/tests/tools/read.test.ts
@@ -40,9 +40,9 @@ describe("handleRead", () => {
     const text = result.content[0].text;
     const lines = text.split("\n").filter(Boolean);
     // Should have 3 content lines + blank + checksum line
-    expect(lines[0]).toMatch(/^1:[a-z]{2}\tconst a = 1;$/);
-    expect(lines[1]).toMatch(/^2:[a-z]{2}\tconst b = 2;$/);
-    expect(lines[2]).toMatch(/^3:[a-z]{2}\tconst c = 3;$/);
+    expect(lines[0]).toMatch(/^1\tconst a = 1;$/);
+    expect(lines[1]).toMatch(/^2\tconst b = 2;$/);
+    expect(lines[2]).toMatch(/^3\tconst c = 3;$/);
   });
 
   test("returns checksum in result", async () => {
@@ -62,9 +62,9 @@ describe("handleRead", () => {
       projectDir: testDir,
     });
     const text = result.content[0].text;
-    const contentLines = text.split("\n").filter((l) => l.match(/^\d+:/));
+    const contentLines = text.split("\n").filter((l) => l.match(/^\d+\t/));
     expect(contentLines).toHaveLength(1);
-    expect(contentLines[0]).toMatch(/^2:[a-z]{2}\tconst b = 2;$/);
+    expect(contentLines[0]).toMatch(/^2\tconst b = 2;$/);
   });
 
   test("denies reading .env file", async () => {
@@ -102,12 +102,12 @@ describe("handleRead", () => {
     expect(checksumMatches).toHaveLength(2);
 
     // Should contain lines 3-5 and 15-17 but not lines 6-14
-    expect(text).toMatch(/^3:/m);
-    expect(text).toMatch(/^5:/m);
-    expect(text).toMatch(/^15:/m);
-    expect(text).toMatch(/^17:/m);
-    expect(text).not.toMatch(/^6:/m);
-    expect(text).not.toMatch(/^14:/m);
+    expect(text).toMatch(/^3\t/m);
+    expect(text).toMatch(/^5\t/m);
+    expect(text).toMatch(/^15\t/m);
+    expect(text).toMatch(/^17\t/m);
+    expect(text).not.toMatch(/^6\t/m);
+    expect(text).not.toMatch(/^14\t/m);
   });
 
   test("reads whole file when ranges omitted", async () => {
@@ -118,8 +118,8 @@ describe("handleRead", () => {
       projectDir: testDir,
     });
     const text = result.content[0].text;
-    expect(text).toContain("1:");
-    expect(text).toContain("3:");
+    expect(text).toMatch(/^1\t/m);
+    expect(text).toMatch(/^3\t/m);
     const checksumMatches = text.match(/^checksum: /gm);
     expect(checksumMatches).toHaveLength(1);
   });
@@ -134,8 +134,8 @@ describe("handleRead", () => {
     });
     expect(result.isError).toBeUndefined();
     const text = result.content[0].text;
-    expect(text).toContain("1:");
-    expect(text).toContain("4:");
+    expect(text).toMatch(/^1\t/m);
+    expect(text).toMatch(/^4\t/m);
     expect(text).toContain("checksum: 1-4:");
   });
 
@@ -156,7 +156,7 @@ describe("handleRead", () => {
     // The decoded content should show "café"
     expect(text).toContain("café");
     // And the hash should be present
-    expect(text).toMatch(/^1:[a-z]{2}\tcafé$/m);
+    expect(text).toMatch(/^1\tcafé$/m);
   });
 
   test("truncates output at 2000 lines", async () => {
@@ -192,16 +192,15 @@ describe("handleRead", () => {
     expect(text).toMatch(/checksum: 100-199:[0-9a-f]{8}/);
   });
 
-  test("hashes=false omits per-line hashes", async () => {
+  test("output format is lineNumber tab content", async () => {
     const result = await handleRead({
       file_path: testFile,
-      hashes: false,
       projectDir: testDir,
     });
     expect(result.isError).toBeUndefined();
     const text = result.content[0].text;
     const lines = text.split("\n").filter(Boolean);
-    // Format should be N\tcontent (no hash)
+    // Format should be N\tcontent (no per-line hash)
     expect(lines[0]).toMatch(/^1\tconst a = 1;$/);
     expect(lines[1]).toMatch(/^2\tconst b = 2;$/);
     expect(lines[2]).toMatch(/^3\tconst c = 3;$/);
@@ -209,10 +208,9 @@ describe("handleRead", () => {
     expect(text).toContain("checksum:");
   });
 
-  test("hashes=false with ranges still has checksums", async () => {
+  test("ranges output still has checksums", async () => {
     const result = await handleRead({
       file_path: testFile,
-      hashes: false,
       ranges: ["1-2"],
       projectDir: testDir,
     });
@@ -220,15 +218,5 @@ describe("handleRead", () => {
     const text = result.content[0].text;
     expect(text).toMatch(/^1\tconst a = 1;\n2\tconst b = 2;\n/);
     expect(text).toContain("checksum: 1-2:");
-  });
-
-  test("hashes defaults to true", async () => {
-    const result = await handleRead({
-      file_path: testFile,
-      projectDir: testDir,
-    });
-    const text = result.content[0].text;
-    // Default should include hashes
-    expect(text.split("\n")[0]).toMatch(/^1:[a-z]{2}\t/);
   });
 });

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -49,8 +49,8 @@ describe("trueline_search", () => {
     expect(text).toContain("world");
     // Should have checksums
     expect(text).toContain("checksum:");
-    // Should have per-line hashes
-    expect(text).toMatch(/\d+:[a-z]{2}\t/);
+    // Should have line number + tab format
+    expect(text).toMatch(/^\d+\t/m);
   });
 
   test("respects context_lines parameter", async () => {

--- a/tests/trueline.test.ts
+++ b/tests/trueline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { fnv1aHash } from "../src/hash.ts";
 import { parseRange, parseChecksum } from "../src/parse.ts";
-import { lineHash, rangeChecksum } from "./helpers.ts";
+import { rangeChecksum } from "./helpers.ts";
 
 describe("fnv1aHash", () => {
   test("empty string produces FNV offset basis", () => {
@@ -26,21 +26,6 @@ describe("fnv1aHash", () => {
     const h = fnv1aHash("🎉");
     expect(typeof h).toBe("number");
     expect(h).toBeGreaterThan(0);
-  });
-});
-
-describe("lineHash", () => {
-  test("returns exactly 2 lowercase letters", () => {
-    const h = lineHash("console.log('hello')");
-    expect(h).toMatch(/^[a-z]{2}$/);
-  });
-
-  test("deterministic", () => {
-    expect(lineHash("foo")).toBe(lineHash("foo"));
-  });
-
-  test("empty line produces valid hash", () => {
-    expect(lineHash("")).toMatch(/^[a-z]{2}$/);
   });
 });
 
@@ -72,37 +57,31 @@ describe("rangeChecksum", () => {
 
 describe("parseRange", () => {
   test("parses valid range", () => {
-    const r = parseRange("12:gh-21:yz");
-    expect(r.start).toEqual({ line: 12, hash: "gh" });
-    expect(r.end).toEqual({ line: 21, hash: "yz" });
+    const r = parseRange("12-21");
+    expect(r.start).toBe(12);
+    expect(r.end).toBe(21);
   });
 
   test("parses single-line range", () => {
-    const r = parseRange("5:ab-5:ab");
-    expect(r.start.line).toBe(5);
-    expect(r.end.line).toBe(5);
+    const r = parseRange("5-5");
+    expect(r.start).toBe(5);
+    expect(r.end).toBe(5);
   });
 
-  test("parses single line:hash as self-range", () => {
-    const r = parseRange("5:ab");
-    expect(r.start).toEqual({ line: 5, hash: "ab" });
-    expect(r.end).toEqual({ line: 5, hash: "ab" });
-  });
-
-  test("single-line shorthand returns independent start/end objects", () => {
-    const r = parseRange("5:ab");
-    expect(r.start).toEqual(r.end);
-    expect(r.start).not.toBe(r.end); // must be distinct objects
+  test("parses single line number as self-range", () => {
+    const r = parseRange("5");
+    expect(r.start).toBe(5);
+    expect(r.end).toBe(5);
   });
 
   test("parses dash-separated range", () => {
-    const r = parseRange("12:gh-21:yz");
-    expect(r.start).toEqual({ line: 12, hash: "gh" });
-    expect(r.end).toEqual({ line: 21, hash: "yz" });
+    const r = parseRange("12-21");
+    expect(r.start).toBe(12);
+    expect(r.end).toBe(21);
   });
 
   test("throws when start > end", () => {
-    expect(() => parseRange("21:ab-12:cd")).toThrow("must be ≤");
+    expect(() => parseRange("21-12")).toThrow("must be ≤");
   });
 });
 


### PR DESCRIPTION
## Summary

Remove per-line 2-letter boundary hashes from the edit protocol. The range checksum alone provides complete integrity verification; per-line hashes were a secondary layer that caused more harm than good.

## Problem

AIs frequently fumbled the compound `startLine:hash-endLine:hash` range format, producing bare line numbers like `"194-301"` instead of `"194:gh-301:yz"`. This wasted a full round-trip on a parse error before any content verification even ran. The per-line hashes only added marginally better error diagnostics ("line 194 shifted" vs "checksum mismatch"), but the AI needs to re-read regardless.

## Changes

**Protocol simplification:**
- Edit range format: `startLine-endLine` instead of `startLine:hash-endLine:hash`
- Read/search output: `lineNumber\tcontent` instead of `lineNumber:hash\tcontent`
- Removed `hashes` parameter from `trueline_read`

**Code removed:**
- `hashToLetters`, `LETTER_TABLE`, `parseLineHash`, `LineRef` interface
- `StreamEditOp.startHash`/`endHash` fields
- Boundary hash verification in `streamingEdit()`

**Kept intact:**
- Internal per-line hash computation (needed for checksum accumulation)
- All checksum verification (the sole integrity mechanism)

**Updated:**
- MCP tool schemas and descriptions
- Hook instructions for all platforms
- Config files for 5 platforms (Claude Code, Gemini CLI, VS Code Copilot, OpenCode, Codex)
- DESIGN.md, README.md, CLAUDE.md
- Benchmarks
- All tests (447 pass)

Net -478 lines across 29 files.