### PR TITLE
fix(hooks): three VS Code Copilot integration bugs on Windows

### DIFF
--- a/bin/trueline-hook.js
+++ b/bin/trueline-hook.js
@@ -13,7 +13,7 @@
 // Reads hook event JSON from stdin (for tool-use hooks), writes platform-
 // formatted JSON to stdout.
 
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolve, dirname } from "node:path";
 
 const hooksDir = resolve(dirname(fileURLToPath(import.meta.url)), "..", "hooks");
@@ -57,13 +57,13 @@ const normalizedEvent = EVENT_ALIASES[event.toLowerCase()] ?? event.toLowerCase(
 // ==============================================================================
 
 if (normalizedEvent === "session-start") {
-  const { getInstructions } = await import(resolve(hooksDir, "core", "instructions.js"));
+  const { getInstructions } = await import(pathToFileURL(resolve(hooksDir, "core", "instructions.js")).href);
   process.stdout.write(getInstructions(platform));
 } else if (normalizedEvent === "pretooluse") {
-  const { createAccessChecker } = await import(resolve(hooksDir, "core", "access.js"));
-  const { routePreToolUse } = await import(resolve(hooksDir, "core", "routing.js"));
-  const { formatDecision } = await import(resolve(hooksDir, "core", "formatters.js"));
-  const { getProjectDir } = await import(resolve(hooksDir, "core", "platform.js"));
+  const { createAccessChecker } = await import(pathToFileURL(resolve(hooksDir, "core", "access.js")).href);
+  const { routePreToolUse } = await import(pathToFileURL(resolve(hooksDir, "core", "routing.js")).href);
+  const { formatDecision } = await import(pathToFileURL(resolve(hooksDir, "core", "formatters.js")).href);
+  const { getProjectDir } = await import(pathToFileURL(resolve(hooksDir, "core", "platform.js")).href);
 
   const chunks = [];
   process.stdin.on("data", (chunk) => chunks.push(chunk));

--- a/hooks/core/platform.js
+++ b/hooks/core/platform.js
@@ -38,5 +38,10 @@ export function detectPlatform() {
 export function getProjectDir(platform) {
   const p = platform ?? detectPlatform();
   const envVar = PLATFORM_ENV_VARS[p];
-  return envVar ? process.env[envVar] : process.env.CLAUDE_PROJECT_DIR;
+  // vscode-copilot isn't in PLATFORM_ENV_VARS (see comment above) and doesn't
+  // set CLAUDE_PROJECT_DIR either, so both branches return undefined for it.
+  // Fall back to process.cwd(): VS Code spawns the hook process with cwd set
+  // to the workspace root, so this resolves correctly without a platform-
+  // specific env var.
+  return envVar ? process.env[envVar] : (process.env.CLAUDE_PROJECT_DIR ?? process.cwd());
 }

--- a/hooks/core/routing.js
+++ b/hooks/core/routing.js
@@ -52,12 +52,15 @@ const BASH_PEEK_DETECTORS = [
 ];
 
 // Different platforms use different field names for file paths in tool input.
-const FILE_PATH_FIELDS = ["file_path", "path", "target_file"];
+// VS Code Copilot's built-in Read/Edit tools use camelCase ("filePath"), unlike
+// the snake_case used by Claude Code/Gemini CLI/OpenCode ("file_path").
+const FILE_PATH_FIELDS = ["file_path", "filePath", "path", "target_file"];
 
 // Fields that indicate a partial/ranged read across platforms:
 //   Claude Code / OpenCode: offset, limit
 //   Gemini CLI: start_line, end_line
-const PARTIAL_READ_FIELDS = ["offset", "limit", "start_line", "end_line"];
+//   VS Code Copilot: startLine, endLine
+const PARTIAL_READ_FIELDS = ["offset", "limit", "start_line", "end_line", "startLine", "endLine"];
 
 // Files at or above this size are blocked with full redirect guidance.
 const LARGE_FILE_THRESHOLD = 10240; // 10KB


### PR DESCRIPTION
## Problem

Four VS Code Copilot-specific integration bugs, all silently no-op'ing on Windows (no crash, the hook just does nothing useful):

1. **`bin/trueline-hook.js`** -- `await import(resolve(hooksDir, "core", "X.js"))` passes a raw Windows path (`C:\...`) to the ESM `import()` loader, which throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` on win32. Every dynamic import in the dispatcher (`instructions.js`, `access.js`, `routing.js`, `formatters.js`, `platform.js`) hits this.
2. **`hooks/core/routing.js`** -- `FILE_PATH_FIELDS` only recognizes snake_case `file_path`. VS Code Copilot's built-in Read/Edit tools send camelCase `filePath`, so `extractFilePath()` returns `null` for every VS Code Copilot tool call and the hook silently passes through with zero routing (no size-based read redirect, no edit advisory).
3. Same file -- `PARTIAL_READ_FIELDS` only recognizes snake_case `start_line`/`end_line` (Gemini CLI). VS Code Copilot sends `startLine`/`endLine`, so partial reads were mis-detected as full reads.
4. **`hooks/core/platform.js`** -- `getProjectDir()` has no `vscode-copilot` entry in `PLATFORM_ENV_VARS` (already flagged in an existing comment), and `vscode-copilot` doesn't set `CLAUDE_PROJECT_DIR` either, so it always returned `undefined` for this platform, breaking `TRUELINE_ALLOWED_DIRS` resolution and the access checker.

## Fix

- Wrap the 5 dynamic imports in `pathToFileURL(...).href`.
- Add `"filePath"` to `FILE_PATH_FIELDS` and `"startLine"`/`"endLine"` to `PARTIAL_READ_FIELDS`.
- Fall back `getProjectDir()` to `process.cwd()` when no platform-specific env var resolves anything -- VS Code spawns the hook process with `cwd` set to the workspace root, so this resolves correctly without needing a new env var.

## Verification

- `bun run lint` and `bun run typecheck` both clean.
- Manually exercised the VS Code Copilot hook path end-to-end against a real VS Code Copilot session (this is exactly the hook config I'm running in production for my own use of trueline-mcp).

## Note on local test validation

Committed with `--no-verify` locally -- see [#12](https://github.com/rjkaes/trueline-mcp/pull/12) for the unrelated local Windows Developer Mode test blocker (same root cause: `symlinkSync` needs Developer Mode, not available on this box, confirmed via A/B testing that it's pre-existing and unrelated to these changes).
